### PR TITLE
fix: not giving a new name for a branch in git reword is a noop

### DIFF
--- a/src/reword.rs
+++ b/src/reword.rs
@@ -30,6 +30,9 @@ pub fn run(target: String, message: Option<String>) -> Result<()> {
                 }
             };
             let new_name = new_name.trim().to_string();
+            if new_name == name {
+                return Ok(());
+            }
             git_branch::validate_name(&new_name)?;
             reword_branch(&repo, &name, &new_name)
         }


### PR DESCRIPTION
Just hitting Enter at the prompt keeps the current branch name, which is a way for the user to say abort, don't rename.

No point in showing "Renamed branch foo to foo", it looks silly.