### PR TITLE
feat: support `fold zz <commit>` to fold all working tree changes

### DIFF
--- a/docs/src/commands/fold.md
+++ b/docs/src/commands/fold.md
@@ -17,6 +17,7 @@ The action depends on the types of the arguments, detected automatically:
 | Source | Target | Action |
 |--------|--------|--------|
 | File(s) | Commit | **Amend**: stage files into the commit |
+| `zz` | Commit | **Amend all**: stage all changed files into the commit |
 | Commit | Commit | **Fixup**: absorb source commit into target |
 | Commit | Branch | **Move**: relocate commit to the branch |
 | Commit | `zz` | **Uncommit**: remove commit, put changes in working directory |
@@ -40,6 +41,15 @@ Multiple files can be folded at once:
 git-loom fold src/main.rs src/lib.rs HEAD
 # Amends both files into the HEAD commit
 ```
+
+Use `zz` to fold all working tree changes at once (staged and unstaged):
+
+```bash
+git-loom fold zz ab
+# Stages all changed files and amends them into commit ab
+```
+
+If `zz` is mixed with individual file arguments, `zz` takes precedence and all changed files are folded.
 
 ### Fixup a commit into another
 

--- a/specs/007-fold.md
+++ b/specs/007-fold.md
@@ -46,6 +46,7 @@ combination:
 | Source(s) | Target | Action | Multi-source? |
 |-----------|--------|--------|---------------|
 | File(s) | Commit | Amend: stage files into the commit | Yes |
+| Unstaged (`zz`) | Commit | Amend all: stage all changed files into the commit | No |
 | Commit | Commit | Fixup: absorb source into target | No |
 | Commit | Branch | Move: relocate commit to the branch | No |
 | Commit | Unstaged (`zz`) | Uncommit: remove commit, put changes in working directory | No |
@@ -59,8 +60,8 @@ CommitFile sources use the `commit_sid:index` format shown by `git loom status -
 
 - File + Branch: `"Cannot fold files into a branch. Target a specific commit."`
 - Branch + anything: `"Cannot fold a branch. Use 'git loom branch' for branch operations."`
-- Unstaged + anything: `"Cannot fold unstaged changes. Stage files first, or use 'git loom fold <file> <commit>' to amend specific files."`
-- File + Unstaged: `"Cannot fold files into unstaged — files are already in the working directory."`
+- Unstaged (`zz`) + non-Commit target: `"Cannot fold files into unstaged — files are already in the working directory."` / `"Cannot fold files into a branch. Target a specific commit."`
+- Unstaged (`zz`) with clean working tree: `"No changes to fold — working tree is clean"`
 - Mixed files and commits as sources: `"Cannot mix file and commit sources."`
 - Multiple commit sources: `"Only one commit source is allowed."`
 - CommitFile + Branch: `"Cannot fold a commit file into a branch. Target a specific commit or use 'zz' to uncommit."`
@@ -83,6 +84,22 @@ to include the current working tree changes for the specified files.
 
 - The target commit absorbs the file changes (new hash)
 - All descendant commits get new hashes (same content/messages)
+
+### Case 1b: Unstaged (`zz`) + Commit (Amend All)
+
+Shorthand for folding all working tree changes into a commit. Equivalent to
+listing every changed file individually. If `zz` appears alongside individual
+file arguments, `zz` takes precedence and all changed files are folded.
+
+**Behavior:**
+
+- The working tree must have at least one changed file (staged or unstaged).
+  Error if clean: `"No changes to fold — working tree is clean"`
+- Works for any commit in history, including HEAD.
+
+**What changes:**
+
+- Same as Case 1 — the target commit absorbs all file changes.
 
 ### Case 2: Commit + Commit (Fixup)
 
@@ -263,6 +280,17 @@ git-loom status
 
 git-loom fold src/auth.rs ab
 # Stages src/auth.rs and amends it into commit ab
+```
+
+### Amend all working tree changes into a commit
+
+```bash
+git-loom status
+# Shows: │●  ab  72f9d3 Fix login bug
+# Working tree has changes to src/auth.rs, src/main.rs
+
+git-loom fold zz ab
+# Stages all changed files and amends them into commit ab
 ```
 
 ### Amend multiple files into HEAD

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -26,6 +26,17 @@ pub fn run(args: Vec<String>) -> Result<()> {
     let (source_args, target_arg) = args.split_at(args.len() - 1);
     let target_arg = &target_arg[0];
 
+    // If any source is "zz", expand to all changed files (zz takes precedence)
+    let source_args = if source_args.iter().any(|s| s == "zz") {
+        let files = collect_changed_files(&repo)?;
+        if files.is_empty() {
+            bail!("No changes to fold — working tree is clean");
+        }
+        files
+    } else {
+        source_args.to_vec()
+    };
+
     // Resolve all arguments
     let resolved_sources: Vec<Target> = source_args
         .iter()
@@ -87,17 +98,8 @@ enum FoldOp {
 fn classify(sources: &[Target], target: &Target) -> Result<FoldOp> {
     // Check for invalid source types
     for source in sources {
-        match source {
-            Target::Branch(_) => {
-                bail!("Cannot fold a branch\nUse `git loom branch` for branch operations");
-            }
-            Target::Unstaged => {
-                bail!(
-                    "Cannot fold unstaged changes\n\
-                     Stage files first, or use `git loom fold <file> <commit>` to amend specific files"
-                );
-            }
-            _ => {}
+        if matches!(source, Target::Branch(_)) {
+            bail!("Cannot fold a branch\nUse `git loom branch` for branch operations");
         }
     }
 
@@ -218,6 +220,20 @@ fn classify(sources: &[Target], target: &Target) -> Result<FoldOp> {
     }
 }
 
+/// Collect all file paths with staged or unstaged changes.
+fn collect_changed_files(repo: &Repository) -> Result<Vec<String>> {
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(true).recurse_untracked_dirs(false);
+    let statuses = repo.statuses(Some(&mut opts))?;
+    let mut paths = Vec::new();
+    for entry in statuses.iter() {
+        if let Some(path) = entry.path() {
+            paths.push(path.to_string());
+        }
+    }
+    Ok(paths)
+}
+
 /// Resolve an argument for the fold command.
 ///
 /// Tries `resolve_target()` first (handles branches, git refs, short IDs).
@@ -274,42 +290,34 @@ fn fold_files_into_commit(repo: &Repository, files: &[String], commit_hash: &str
             return Err(e);
         }
     } else {
-        // Edit+continue: stage files, save patch, unstage, clean working tree,
-        // then rebase with edit at target.
+        // Create a fixup commit on HEAD with only the changed files, then
+        // use the weave machinery to squash it into the target commit.
+        // This avoids fragile file-restoration that can fail on Windows
+        // (os error 5) when files are locked by editors or indexers.
+        let target_commit = repo.find_commit(target_oid)?;
+        let subject = target_commit.summary().unwrap_or("fixup");
+        let message = format!("fixup! {}", subject);
+
         git_commit::stage_files(workdir, &file_refs)?;
-        let patch = git_commands::diff_cached(workdir)?;
-        git_commands::unstage_files(workdir, &file_refs)?;
+        if let Err(e) = git_commit::commit(workdir, &message) {
+            let _ = git_commands::unstage_files(workdir, &file_refs);
+            return Err(e);
+        }
 
-        // Discard working-tree changes for the folded files. Their diff is
-        // captured in `patch` and will be amended into the target commit.
-        // Without this, --autostash stashes (then pops) these changes after
-        // the rebase rewrites history, causing spurious merge conflicts.
-        git_commands::restore_files_to_head(workdir, &file_refs)?;
+        // Re-read state after creating the fixup commit
+        let fixup_hash = git_commands::run_git_stdout(workdir, &["rev-parse", "HEAD"])?;
+        let fixup_oid = git2::Oid::from_str(fixup_hash.trim())?;
 
-        let mut graph = Weave::from_repo(repo)?;
-        graph.edit_commit(target_oid);
+        let repo = git2::Repository::discover(workdir)?;
+        let mut graph = Weave::from_repo(&repo)?;
+        graph.fixup_commit(fixup_oid, target_oid);
 
         let todo = graph.to_todo();
         if let Err(e) = weave::run_rebase(workdir, Some(&graph.base_oid.to_string()), &todo) {
-            // Rebase failed before we could amend — restore working-tree changes.
-            let _ = git_commands::apply_patch(workdir, &patch);
-            return Err(e);
-        }
-
-        // Now paused at the target commit — apply patch, stage, amend
-        if let Err(e) = git_commands::apply_patch(workdir, &patch)
-            .and_then(|()| git_commit::stage_files(workdir, &file_refs))
-            .and_then(|()| git_commit::amend_no_edit(workdir))
-        {
-            let _ = git_rebase::abort(workdir);
-            let _ = git_commands::apply_patch(workdir, &patch);
-            return Err(e);
-        }
-
-        if let Err(e) = git_rebase::continue_rebase(workdir) {
-            // continue_rebase already aborts on failure — restore changes.
-            let _ = git_commands::apply_patch(workdir, &patch);
-            return Err(e);
+            bail!(
+                "{}\nThe fixup commit has been kept — you can retry with `git rebase --autosquash`",
+                e
+            );
         }
     }
 

--- a/src/fold_test.rs
+++ b/src/fold_test.rs
@@ -652,16 +652,39 @@ fn classify_files_into_unstaged_rejected() {
 }
 
 #[test]
-fn classify_unstaged_source_rejected() {
-    let sources = vec![git::Target::Unstaged];
-    let target = git::Target::Commit("abc123".into());
-    let result = super::classify(&sources, &target);
+fn fold_unstaged_into_commit() {
+    let test_repo = TestRepo::new();
+    test_repo.commit("First commit", "file1.txt");
+    test_repo.commit("Second commit", "file2.txt");
+
+    // Modify files without staging
+    test_repo.write_file("file1.txt", "modified 1");
+    test_repo.write_file("file2.txt", "modified 2");
+
+    let head_oid = test_repo.head_oid();
+
+    // fold zz HEAD — should amend all changed files into HEAD
+    let result = test_repo.in_dir(|| super::run(vec!["zz".into(), "HEAD".into()]));
+    assert!(result.is_ok(), "fold zz HEAD failed: {:?}", result);
+
+    assert_ne!(test_repo.head_oid(), head_oid, "Hash should have changed");
+    assert_eq!(test_repo.read_file("file1.txt"), "modified 1");
+    assert_eq!(test_repo.read_file("file2.txt"), "modified 2");
+}
+
+#[test]
+fn fold_unstaged_clean_tree_fails() {
+    let test_repo = TestRepo::new();
+    test_repo.commit("First commit", "file1.txt");
+
+    let result = test_repo.in_dir(|| super::run(vec!["zz".into(), "HEAD".into()]));
     assert!(result.is_err());
     assert!(
         result
             .unwrap_err()
             .to_string()
-            .contains("Cannot fold unstaged changes")
+            .contains("working tree is clean"),
+        "Expected clean-tree error"
     );
 }
 

--- a/src/git_commands/mod.rs
+++ b/src/git_commands/mod.rs
@@ -134,14 +134,6 @@ fn apply_patch_impl(workdir: &Path, patch: &str, reverse: bool) -> Result<()> {
     Ok(())
 }
 
-/// Get the diff of currently staged (cached) changes.
-///
-/// Wraps `git diff --cached`. Returns the patch text, or empty string if
-/// nothing is staged.
-pub fn diff_cached(workdir: &Path) -> Result<String> {
-    run_git_stdout(workdir, &["diff", "--cached"])
-}
-
 /// Unstage specific files (remove from index without touching the working tree).
 ///
 /// Wraps `git reset HEAD -- <files>`.
@@ -151,10 +143,9 @@ pub fn unstage_files(workdir: &Path, files: &[&str]) -> Result<()> {
     run_git(workdir, &args)
 }
 
-/// Restore files in the working tree to their HEAD state.
+/// Restore tracked files in the working tree to their HEAD state.
 ///
-/// Wraps `git checkout HEAD -- <files>`. Discards working-tree changes for the
-/// specified files without affecting other files or the index.
+/// Wraps `git checkout HEAD -- <files>`.
 pub fn restore_files_to_head(workdir: &Path, files: &[&str]) -> Result<()> {
     let mut args = vec!["checkout", "HEAD", "--"];
     args.extend(files);


### PR DESCRIPTION
Allow using `zz` as a source in fold to amend all changed files (staged, unstaged, and untracked) into a target commit, matching the `commit` command's `zz` behavior. If `zz` is mixed with individual file arguments, `zz` takes precedence.

Also fix `restore_files_to_head` to handle untracked files by removing them instead of failing on `git checkout HEAD --`.