### PR TITLE
fix(branch): Fix creation of branch on a commit which resolves to HEAD

### DIFF
--- a/specs/005-branch.md
+++ b/specs/005-branch.md
@@ -79,11 +79,13 @@ origin/main → A1 → A2 (feature-a)
 
 **When weaving triggers:**
 
-Weaving occurs only when the branch target is on the **first-parent line** from
-HEAD to the merge-base (i.e., a loose commit on the integration line). These
-cases are no-ops:
+Weaving occurs when the branch target is on the **first-parent line** from HEAD
+to the merge-base (i.e., a loose commit on the integration line), including HEAD
+itself. Branching at HEAD moves all first-parent commits into the new branch
+section with a merge commit.
 
-- **Branch at HEAD**: No commits to split off, topology stays linear.
+These cases are no-ops:
+
 - **Branch at merge-base**: Branch has no owned commits in the range, no topology
   change needed.
 - **Branch inside an existing side branch**: The commit is already part of a

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -79,16 +79,22 @@ pub fn run(name: Option<String>, target: Option<String>) -> Result<()> {
 ///
 /// Weaving is needed when the branch target is on the first-parent line
 /// from HEAD to the merge-base (i.e., it's a loose commit on the integration
-/// line, not already on a side branch). Commits at HEAD or the merge-base
-/// are excluded since no topology change is needed for those.
+/// line, not already on a side branch). Commits at the merge-base are excluded
+/// since no topology change is needed. Branching at HEAD weaves all first-parent
+/// commits into the new branch section with a merge commit.
 fn should_weave(info: &git::RepoInfo, repo: &Repository, commit_hash: &str) -> Result<bool> {
     let head_oid = git::head_oid(repo)?;
     let branch_oid = git2::Oid::from_str(commit_hash)?;
 
     let merge_base_oid = info.upstream.merge_base_oid;
 
-    if branch_oid == head_oid || branch_oid == merge_base_oid {
+    if branch_oid == merge_base_oid {
         return Ok(false);
+    }
+
+    // HEAD is on the first-parent line by definition
+    if branch_oid == head_oid {
+        return Ok(true);
     }
 
     // Only weave if the target commit is on the first-parent line.

--- a/src/branch_test.rs
+++ b/src/branch_test.rs
@@ -218,8 +218,8 @@ fn branch_weave_creates_merge_topology() {
 }
 
 #[test]
-fn branch_at_head_no_weave() {
-    // Branch at HEAD should NOT create a merge
+fn branch_at_head_weaves() {
+    // Branch at HEAD should weave all first-parent commits into the branch
     let test_repo = TestRepo::new_with_remote();
     test_repo.commit("A1", "a1.txt");
     test_repo.commit("A2", "a2.txt");
@@ -229,14 +229,24 @@ fn branch_at_head_no_weave() {
         .in_dir(|| super::run(Some("feature-a".to_string()), Some(head_before.to_string())));
 
     assert!(result.is_ok(), "branch::run failed: {:?}", result.err());
+    assert!(test_repo.branch_exists("feature-a"));
 
-    // HEAD should be unchanged (no merge commit)
-    assert_eq!(test_repo.head_oid(), head_before);
+    // HEAD should now be a merge commit (weaving happened)
     let head = test_repo.head_commit();
     assert_eq!(
         head.parent_count(),
-        1,
-        "HEAD should NOT be a merge commit when branching at HEAD"
+        2,
+        "HEAD should be a merge commit when branching at HEAD"
+    );
+
+    // One parent should be the feature-a branch tip
+    let parent_oids: Vec<git2::Oid> = (0..head.parent_count())
+        .map(|i| head.parent_id(i).unwrap())
+        .collect();
+    let feature_a_oid = test_repo.get_branch_target("feature-a");
+    assert!(
+        parent_oids.contains(&feature_a_oid),
+        "merge commit should have feature-a as a parent"
     );
 }
 


### PR DESCRIPTION
When the target commit resolves to HEAD, we need to create a branch and weave it into integration.