### PR TITLE
fix(weave): add # comment marker before commit messages in todo

### DIFF
--- a/src/weave.rs
+++ b/src/weave.rs
@@ -105,7 +105,7 @@ impl Weave {
                         pending_refs.clear();
                     }
                     out.push_str(&format!(
-                        "{} {} {}\n",
+                        "{} {} # {}\n",
                         commit.command.as_str(),
                         commit.short_hash,
                         commit.message
@@ -656,7 +656,7 @@ fn emit_commits_with_refs(out: &mut String, commits: &[CommitEntry]) -> Vec<Stri
             pending_refs.clear();
         }
         out.push_str(&format!(
-            "{} {} {}\n",
+            "{} {} # {}\n",
             commit.command.as_str(),
             commit.short_hash,
             commit.message
@@ -834,7 +834,7 @@ fn build_and_run_linear_edit(repo: &Repository, workdir: &Path, commit_oid: Oid)
         } else {
             "pick"
         };
-        entries.push(format!("{} {} {}", cmd, short, msg));
+        entries.push(format!("{} {} # {}", cmd, short, msg));
 
         if c.parent_count() == 0 {
             break;

--- a/src/weave_test.rs
+++ b/src/weave_test.rs
@@ -70,13 +70,13 @@ fn serialize_single_branch_section() {
     assert_eq!(lines[0], "label onto");
     assert_eq!(lines[1], "");
     assert_eq!(lines[2], "reset onto");
-    assert_eq!(lines[3], &format!("pick {} A1", OID_A1));
-    assert_eq!(lines[4], &format!("pick {} A2", OID_A2));
+    assert_eq!(lines[3], &format!("pick {} # A1", OID_A1));
+    assert_eq!(lines[4], &format!("pick {} # A2", OID_A2));
     assert_eq!(lines[5], "label feature-a");
     assert_eq!(lines[6], "update-ref refs/heads/feature-a");
     assert_eq!(lines[7], "");
     assert_eq!(lines[8], "reset onto");
-    assert_eq!(lines[9], &format!("pick {} Int", OID_INT));
+    assert_eq!(lines[9], &format!("pick {} # Int", OID_INT));
     assert!(lines[10].starts_with(&format!("merge -C {} feature-a", OID_MERGE1)));
 }
 
@@ -176,7 +176,7 @@ fn serialize_update_refs_on_integration_line() {
     };
 
     let todo = graph.to_todo();
-    assert!(todo.contains(&format!("pick {} C1\n", OID_C1)));
+    assert!(todo.contains(&format!("pick {} # C1\n", OID_C1)));
     assert!(todo.contains("update-ref refs/heads/non-woven\n"));
 }
 


### PR DESCRIPTION
Match git's rebase todo format where pick/edit/fixup lines use `pick <hash> # <subject>` instead of `pick <hash> <subject>`.