### PR TITLE
docs: update usage instructions for the no command case

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cargo install --path .
 ## Usage
 
 ```
-Usage: git-loom.exe [OPTIONS] [CONTEXT] [COMMAND]
+Usage: git-loom.exe [OPTIONS] [COMMAND]
 
 Commands:
   init    Initialize a new integration branch tracking a remote
@@ -81,12 +81,8 @@ Commands:
   trace   Show the latest command trace
   help    Print this message or the help of the given subcommand(s)
 
-Arguments:
-  [CONTEXT]  Number of context commits to show before the base [default: 1]
-
 Options:
       --no-color  Disable colored output
-  -f, --files     Show files changed in each commit
   -h, --help      Print help
   -V, --version   Print version
 ```

--- a/docs/src/commands/README.md
+++ b/docs/src/commands/README.md
@@ -1,7 +1,7 @@
 # Commands Overview
 
 ```
-Usage: git-loom.exe [OPTIONS] [CONTEXT] [COMMAND]
+Usage: git-loom.exe [OPTIONS] [COMMAND]
 
 Commands:
   init    Initialize a new integration branch tracking a remote
@@ -19,12 +19,8 @@ Commands:
   trace   Show the latest command trace
   help    Print this message or the help of the given subcommand(s)
 
-Arguments:
-  [CONTEXT]  Number of context commits to show before the base [default: 1]
-
 Options:
       --no-color  Disable colored output
-  -f, --files     Show files changed in each commit
   -h, --help      Print help
   -V, --version   Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,11 +36,11 @@ struct Cli {
     no_color: bool,
 
     /// Show files changed in each commit
-    #[arg(short = 'f', long = "files")]
+    #[arg(short = 'f', long = "files", hide = true)]
     files: bool,
 
     /// Number of context commits to show before the base
-    #[arg(default_value = "1")]
+    #[arg(default_value = "1", hide = true)]
     context: usize,
 
     #[command(subcommand)]
@@ -71,7 +71,7 @@ enum Command {
         /// Commit message (if not provided, opens editor)
         #[arg(short, long)]
         message: Option<String>,
-        /// Files to stage (short IDs, filenames, or 'zz' for all)
+        /// Files to stage (short IDs, filenames, or 'zz' for all), none for all tracked changes
         files: Vec<String>,
     },
     /// Fold source(s) into a target (amend files, fixup commits, move commits)


### PR DESCRIPTION
Don't show the context and `-f`` flags, they are in status.