### PR TITLE
refactor(tests): extract common git ops into TestRepo helpers

### DIFF
--- a/src/absorb_test.rs
+++ b/src/absorb_test.rs
@@ -1,4 +1,3 @@
-use crate::git_commands::{self, git_branch, git_commit, git_merge};
 use crate::test_helpers::TestRepo;
 
 // ── Unit tests for diff parsing ──────────────────────────────────────
@@ -61,14 +60,7 @@ fn absorb_single_file() {
         assert!(result.is_ok(), "absorb failed: {:?}", result);
 
         // file1.txt should now be clean (absorbed into the commit)
-        let repo = crate::git::open_repo().unwrap();
-        let workdir = repo.workdir().unwrap();
-        let diff = git_commands::diff_head_name_only(workdir).unwrap();
-        assert!(
-            diff.trim().is_empty(),
-            "working tree should be clean after absorb, but has: {}",
-            diff
-        );
+        test_repo.assert_working_tree_clean();
 
         // Commit message should be preserved
         assert_eq!(test_repo.get_message(0), "Add file1");
@@ -91,14 +83,7 @@ fn absorb_multiple_files_different_commits() {
         assert!(result.is_ok(), "absorb failed: {:?}", result);
 
         // Both files should be clean
-        let repo = crate::git::open_repo().unwrap();
-        let workdir = repo.workdir().unwrap();
-        let diff = git_commands::diff_head_name_only(workdir).unwrap();
-        assert!(
-            diff.trim().is_empty(),
-            "working tree should be clean, but has: {}",
-            diff
-        );
+        test_repo.assert_working_tree_clean();
 
         // Commit messages preserved
         assert_eq!(test_repo.get_message(0), "Add file2");
@@ -133,12 +118,10 @@ fn absorb_skips_new_file() {
 #[test]
 fn absorb_skips_pure_addition() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
-
     // Write multi-line content and commit it manually (so file content != message)
     test_repo.write_file("file1.txt", "line1\nline2\n");
-    git_commit::stage_files(workdir.as_path(), &["file1.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Add file1").unwrap();
+    test_repo.stage_files(&["file1.txt"]);
+    test_repo.commit_staged("Add file1");
 
     // Add lines without modifying existing ones
     test_repo.write_file("file1.txt", "line1\nline2\nnew line3\n");
@@ -249,17 +232,15 @@ fn absorb_preserves_skipped_changes() {
 #[test]
 fn absorb_skips_multiple_sources() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
-
     // Create two commits each introducing content in the same file.
     // Use manual staging to control exact file content per commit.
     test_repo.write_file("shared.txt", "line1 from c1\n");
-    git_commit::stage_files(workdir.as_path(), &["shared.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Commit 1").unwrap();
+    test_repo.stage_files(&["shared.txt"]);
+    test_repo.commit_staged("Commit 1");
 
     test_repo.write_file("shared.txt", "line1 from c1\nline2 from c2\n");
-    git_commit::stage_files(workdir.as_path(), &["shared.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Commit 2").unwrap();
+    test_repo.stage_files(&["shared.txt"]);
+    test_repo.commit_staged("Commit 2");
 
     // Modify lines from both commits
     test_repo.write_file("shared.txt", "MODIFIED line1\nMODIFIED line2\n");
@@ -296,19 +277,18 @@ fn absorb_skips_out_of_scope() {
 #[test]
 fn absorb_with_woven_branches() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature branch off base with a commit
-    git_branch::create(workdir.as_path(), "feat1", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feat1", &base_oid.to_string());
     test_repo.switch_branch("feat1");
     test_repo.write_file("feature.txt", "initial feature content");
-    git_commit::stage_files(workdir.as_path(), &["feature.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Feature 1").unwrap();
+    test_repo.stage_files(&["feature.txt"]);
+    test_repo.commit_staged("Feature 1");
 
     // Merge feat1 into integration branch
     test_repo.switch_branch("integration");
-    git_merge::merge_no_ff(workdir.as_path(), "feat1").unwrap();
+    test_repo.merge_no_ff("feat1");
 
     // Modify the feature file in working tree
     test_repo.write_file("feature.txt", "updated feature content");
@@ -322,13 +302,6 @@ fn absorb_with_woven_branches() {
         );
 
         // Working tree should be clean (feature.txt absorbed)
-        let repo = crate::git::open_repo().unwrap();
-        let wd = repo.workdir().unwrap();
-        let diff = git_commands::diff_head_name_only(wd).unwrap();
-        assert!(
-            diff.trim().is_empty(),
-            "working tree should be clean, but has: {}",
-            diff
-        );
+        test_repo.assert_working_tree_clean();
     });
 }

--- a/src/branch_test.rs
+++ b/src/branch_test.rs
@@ -1,75 +1,5 @@
 use crate::git;
-use crate::git_commands::git_branch;
 use crate::test_helpers::TestRepo;
-
-#[test]
-fn branch_at_merge_base_default() {
-    let test_repo = TestRepo::new_with_remote();
-    test_repo.commit_empty("A1");
-    test_repo.commit_empty("A2");
-
-    let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
-    let base_oid = test_repo.find_remote_branch_target("origin/main");
-
-    // Create branch at merge-base (default, no target)
-    let base = test_repo
-        .repo
-        .revparse_single(&info.upstream.base_short_id)
-        .unwrap();
-    git_branch::create(
-        test_repo.workdir().as_path(),
-        "feature-a",
-        &base.id().to_string(),
-    )
-    .unwrap();
-
-    assert!(test_repo.branch_exists("feature-a"));
-    assert_eq!(test_repo.get_branch_target("feature-a"), base_oid);
-}
-
-#[test]
-fn branch_at_specific_commit() {
-    let test_repo = TestRepo::new_with_remote();
-    let a1_oid = test_repo.commit_empty("A1");
-    test_repo.commit_empty("A2");
-
-    git_branch::create(
-        test_repo.workdir().as_path(),
-        "feature-a",
-        &a1_oid.to_string(),
-    )
-    .unwrap();
-
-    assert!(test_repo.branch_exists("feature-a"));
-    assert_eq!(test_repo.get_branch_target("feature-a"), a1_oid);
-}
-
-#[test]
-fn branch_at_branch_tip() {
-    let test_repo = TestRepo::new_with_remote();
-    let a1_oid = test_repo.commit_empty("A1");
-    test_repo.create_branch_at_commit("feature-a", a1_oid);
-    test_repo.commit_empty("A2");
-
-    let hash = test_repo.get_branch_target("feature-a").to_string();
-    git_branch::create(test_repo.workdir().as_path(), "feature-b", &hash).unwrap();
-
-    assert!(test_repo.branch_exists("feature-b"));
-    assert_eq!(test_repo.get_branch_target("feature-b"), a1_oid);
-}
-
-#[test]
-fn branch_duplicate_name_fails() {
-    let test_repo = TestRepo::new_with_remote();
-    test_repo.commit_empty("A1");
-
-    let head_oid = test_repo.head_oid().to_string();
-    git_branch::create(test_repo.workdir().as_path(), "feature-a", &head_oid).unwrap();
-
-    // Creating a branch with the same name should fail
-    let result = git_branch::create(test_repo.workdir().as_path(), "feature-a", &head_oid);
-    assert!(result.is_err());
-}
 
 #[test]
 fn branch_shows_in_status() {
@@ -77,12 +7,7 @@ fn branch_shows_in_status() {
     let a1_oid = test_repo.commit_empty("A1");
     test_repo.commit_empty("A2");
 
-    git_branch::create(
-        test_repo.workdir().as_path(),
-        "feature-a",
-        &a1_oid.to_string(),
-    )
-    .unwrap();
+    test_repo.create_branch_at("feature-a", &a1_oid.to_string());
 
     let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
     let branch_names: Vec<&str> = info.branches.iter().map(|b| b.name.as_str()).collect();
@@ -108,32 +33,21 @@ fn branch_ownership_splits_commits() {
     let b1_oid = test_repo.commit_empty("B1");
     test_repo.commit_empty("B2");
 
-    git_branch::create(
-        test_repo.workdir().as_path(),
-        "feature-a",
-        &a1_oid.to_string(),
-    )
-    .unwrap();
-    git_branch::create(
-        test_repo.workdir().as_path(),
-        "feature-b",
-        &b1_oid.to_string(),
-    )
-    .unwrap();
+    test_repo.create_branch_at("feature-a", &a1_oid.to_string());
+    test_repo.create_branch_at("feature-b", &b1_oid.to_string());
 
-    let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
-    assert_eq!(info.branches.len(), 2);
+    assert_eq!(test_repo.branch_names().len(), 2);
 }
 
 #[test]
 fn branch_invalid_name_fails() {
-    let result = git_branch::validate_name("my..branch");
+    let result = crate::git_commands::git_branch::validate_name("my..branch");
     assert!(result.is_err(), "double dots should be invalid");
 
-    let result = git_branch::validate_name("has space");
+    let result = crate::git_commands::git_branch::validate_name("has space");
     assert!(result.is_err(), "spaces should be invalid");
 
-    let result = git_branch::validate_name("valid-name");
+    let result = crate::git_commands::git_branch::validate_name("valid-name");
     assert!(result.is_ok(), "valid name should pass");
 }
 
@@ -281,8 +195,6 @@ fn branch_inside_existing_branch_no_weave() {
     // Setup: origin/main → A1 → A2 (feature-a) merged into integration
     //        with B1 on the integration line
     // Then create feature-b at A1 (inside feature-a's side branch)
-    use crate::git_commands::git_merge;
-
     let test_repo = TestRepo::new_with_remote();
 
     // Build a side branch: A1 → A2
@@ -292,12 +204,7 @@ fn branch_inside_existing_branch_no_weave() {
     let a2_oid = test_repo.head_oid();
 
     // Create feature-a branch at A2
-    git_branch::create(
-        test_repo.workdir().as_path(),
-        "feature-a",
-        &a2_oid.to_string(),
-    )
-    .unwrap();
+    test_repo.create_branch_at("feature-a", &a2_oid.to_string());
 
     // Reset integration to merge-base, add a commit on integration line, then merge feature-a
     let base_oid = test_repo.find_remote_branch_target("origin/main");
@@ -307,7 +214,7 @@ fn branch_inside_existing_branch_no_weave() {
     test_repo.commit("B1", "b1.txt");
 
     // Merge feature-a into integration
-    git_merge::merge_no_ff(test_repo.workdir().as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
     let head_before = test_repo.head_oid();
 
     // Now create feature-b at A1, which is inside the feature-a side branch

--- a/src/commit_test.rs
+++ b/src/commit_test.rs
@@ -1,4 +1,3 @@
-use crate::git_commands::{git_branch, git_merge};
 use crate::test_helpers::TestRepo;
 
 /// Helper: set up a test repo with an empty feature branch at the merge-base.
@@ -11,12 +10,7 @@ fn setup_with_woven_branch() -> TestRepo {
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at merge-base (no merge — it's empty)
-    git_branch::create(
-        test_repo.workdir().as_path(),
-        "feature-a",
-        &base_oid.to_string(),
-    )
-    .unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
 
     test_repo
 }
@@ -30,24 +24,23 @@ fn setup_with_woven_branch() -> TestRepo {
 ///               (feature-b)       ↗
 fn setup_with_two_branches() -> TestRepo {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at merge-base with one commit
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
     test_repo.commit("A1", "a1.txt");
     test_repo.switch_branch("integration");
 
     // Create feature-b at merge-base with one commit
-    git_branch::create(workdir.as_path(), "feature-b", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-b", &base_oid.to_string());
     test_repo.switch_branch("feature-b");
     test_repo.commit("B1", "b1.txt");
     test_repo.switch_branch("integration");
 
     // Weave both branches into integration
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
-    git_merge::merge_no_ff(workdir.as_path(), "feature-b").unwrap();
+    test_repo.merge_no_ff("feature-a");
+    test_repo.merge_no_ff("feature-b");
 
     test_repo
 }
@@ -72,9 +65,7 @@ fn commit_stages_specific_file() {
     assert!(result.is_ok(), "commit failed: {:?}", result);
 
     // feature-a should have the commit
-    let branch_oid = test_repo.get_branch_target("feature-a");
-    let commit = test_repo.find_commit(branch_oid);
-    assert_eq!(commit.summary().unwrap(), "Add new file");
+    assert_eq!(test_repo.branch_commit_summary("feature-a"), "Add new file");
 }
 
 #[test]
@@ -95,9 +86,7 @@ fn commit_stages_zz_all_changes() {
     assert!(result.is_ok(), "commit failed: {:?}", result);
 
     // feature-a should have the commit
-    let branch_oid = test_repo.get_branch_target("feature-a");
-    let commit = test_repo.find_commit(branch_oid);
-    assert_eq!(commit.summary().unwrap(), "Add files");
+    assert_eq!(test_repo.branch_commit_summary("feature-a"), "Add files");
 }
 
 #[test]
@@ -106,8 +95,7 @@ fn commit_uses_already_staged() {
 
     // Stage a file manually
     test_repo.write_file("staged.txt", "content");
-    crate::git_commands::git_commit::stage_files(test_repo.workdir().as_path(), &["staged.txt"])
-        .unwrap();
+    test_repo.stage_files(&["staged.txt"]);
 
     let result = test_repo.in_dir(|| {
         super::run(
@@ -119,9 +107,7 @@ fn commit_uses_already_staged() {
 
     assert!(result.is_ok(), "commit failed: {:?}", result);
 
-    let branch_oid = test_repo.get_branch_target("feature-a");
-    let commit = test_repo.find_commit(branch_oid);
-    assert_eq!(commit.summary().unwrap(), "Use staged");
+    assert_eq!(test_repo.branch_commit_summary("feature-a"), "Use staged");
 }
 
 #[test]
@@ -189,9 +175,7 @@ fn commit_to_new_branch_creates_and_weaves() {
     assert!(test_repo.branch_exists("feature-new"));
 
     // Branch should have the commit
-    let branch_oid = test_repo.get_branch_target("feature-new");
-    let commit = test_repo.find_commit(branch_oid);
-    assert_eq!(commit.summary().unwrap(), "Add file");
+    assert_eq!(test_repo.branch_commit_summary("feature-new"), "Add file");
 
     // Integration HEAD should be a merge commit (proper weave topology)
     let head = test_repo.head_commit();
@@ -251,20 +235,19 @@ fn commit_to_empty_branch_creates_merge_topology() {
 ///   HEAD = integration = Merge feature-a
 fn setup_with_one_woven_one_empty() -> TestRepo {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at merge-base with one commit
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
     test_repo.commit("A1", "a1.txt");
     test_repo.switch_branch("integration");
 
     // Weave feature-a into integration
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
 
     // Create feature-b at merge-base (empty, no commits)
-    git_branch::create(workdir.as_path(), "feature-b", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-b", &base_oid.to_string());
 
     test_repo
 }
@@ -345,9 +328,7 @@ fn commit_moves_to_correct_branch_in_topology() {
     assert_eq!(parent.summary().unwrap(), "A1");
 
     // feature-b should still be intact
-    let branch_b_oid = test_repo.get_branch_target("feature-b");
-    let commit_b = test_repo.find_commit(branch_b_oid);
-    assert_eq!(commit_b.summary().unwrap(), "B1");
+    assert_eq!(test_repo.branch_commit_summary("feature-b"), "B1");
 }
 
 /// Bug: committing to a new branch when the file conflicts with an existing
@@ -356,19 +337,18 @@ fn commit_moves_to_correct_branch_in_topology() {
 #[test]
 fn commit_conflict_preserves_working_tree_changes() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feat1 branch with a commit that adds feature1
-    git_branch::create(workdir.as_path(), "feat1", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feat1", &base_oid.to_string());
     test_repo.switch_branch("feat1");
     test_repo.write_file("feature1", "feat 1 content");
-    crate::git_commands::git_commit::stage_files(workdir.as_path(), &["feature1"]).unwrap();
-    crate::git_commands::git_commit::commit(workdir.as_path(), "Feature 1").unwrap();
+    test_repo.stage_files(&["feature1"]);
+    test_repo.commit_staged("Feature 1");
     test_repo.switch_branch("integration");
 
     // Weave feat1 into integration
-    git_merge::merge_no_ff(workdir.as_path(), "feat1").unwrap();
+    test_repo.merge_no_ff("feat1");
 
     // Modify feature1 in the working tree (same file as feat1 commit)
     test_repo.write_file("feature1", "conflicting content");

--- a/src/drop_test.rs
+++ b/src/drop_test.rs
@@ -1,5 +1,3 @@
-use crate::git;
-use crate::git_commands::{git_branch, git_merge};
 use crate::test_helpers::TestRepo;
 
 // ── Helper: create a woven branch with commits ─────────────────────────
@@ -18,11 +16,10 @@ use crate::test_helpers::TestRepo;
 /// ```
 fn setup_woven_branch(num_commits: usize) -> TestRepo {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at merge-base
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
 
     // Switch to feature-a and add commits
     test_repo.switch_branch("feature-a");
@@ -37,7 +34,7 @@ fn setup_woven_branch(num_commits: usize) -> TestRepo {
     test_repo.commit("Int", "int.txt");
 
     // Merge feature-a (creates a real merge commit since integration diverged)
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
 
     test_repo
 }
@@ -124,11 +121,13 @@ fn drop_woven_branch_removes_commits_and_ref() {
     );
 
     // A1, A2 are gone from history, Int should remain
-    let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
-    let messages: Vec<&str> = info.commits.iter().map(|c| c.message.as_str()).collect();
-    assert!(!messages.contains(&"A1"), "A1 should be gone");
-    assert!(!messages.contains(&"A2"), "A2 should be gone");
-    assert!(messages.contains(&"Int"), "Int commit should remain");
+    let messages = test_repo.commit_messages();
+    assert!(!messages.contains(&"A1".to_string()), "A1 should be gone");
+    assert!(!messages.contains(&"A2".to_string()), "A2 should be gone");
+    assert!(
+        messages.contains(&"Int".to_string()),
+        "Int commit should remain"
+    );
 }
 
 #[test]
@@ -137,12 +136,7 @@ fn drop_branch_at_merge_base_just_deletes_ref() {
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create a branch at merge-base (no commits, no weaving)
-    git_branch::create(
-        test_repo.workdir().as_path(),
-        "empty-branch",
-        &base_oid.to_string(),
-    )
-    .unwrap();
+    test_repo.create_branch_at("empty-branch", &base_oid.to_string());
 
     // Add a commit on integration so there's something in the range
     test_repo.commit("C1", "c1.txt");
@@ -162,18 +156,17 @@ fn drop_branch_at_merge_base_just_deletes_ref() {
 #[test]
 fn drop_non_woven_branch_removes_commits_and_ref() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at merge-base and add commits
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
     test_repo.commit("A1", "a1.txt");
     test_repo.commit("A2", "a2.txt");
 
     // Switch back to integration and fast-forward merge feature-a
     test_repo.switch_branch("integration");
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
 
     // Force checkout to sync working tree after merge
     test_repo.force_checkout();
@@ -190,11 +183,13 @@ fn drop_non_woven_branch_removes_commits_and_ref() {
     );
 
     // A1, A2 should be gone, Int should remain
-    let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
-    let messages: Vec<&str> = info.commits.iter().map(|c| c.message.as_str()).collect();
-    assert!(!messages.contains(&"A1"), "A1 should be gone");
-    assert!(!messages.contains(&"A2"), "A2 should be gone");
-    assert!(messages.contains(&"Int"), "Int commit should remain");
+    let messages = test_repo.commit_messages();
+    assert!(!messages.contains(&"A1".to_string()), "A1 should be gone");
+    assert!(!messages.contains(&"A2".to_string()), "A2 should be gone");
+    assert!(
+        messages.contains(&"Int".to_string()),
+        "Int commit should remain"
+    );
 }
 
 #[test]
@@ -211,26 +206,25 @@ fn drop_file_target_fails() {
 #[test]
 fn drop_woven_branch_with_two_branches_preserves_other() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a with commits
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
     test_repo.commit("A1", "a1.txt");
     test_repo.commit("A2", "a2.txt");
     test_repo.switch_branch("integration");
 
     // Create feature-b with commits
-    git_branch::create(workdir.as_path(), "feature-b", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-b", &base_oid.to_string());
     test_repo.switch_branch("feature-b");
     test_repo.commit("B1", "b1.txt");
     test_repo.switch_branch("integration");
 
     // Add integration commit to prevent fast-forward, then weave both
     test_repo.commit("Int", "int.txt");
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
-    git_merge::merge_no_ff(workdir.as_path(), "feature-b").unwrap();
+    test_repo.merge_no_ff("feature-a");
+    test_repo.merge_no_ff("feature-b");
 
     // Drop feature-a
     let result = super::drop_branch(&test_repo.repo, "feature-a", true);
@@ -241,11 +235,10 @@ fn drop_woven_branch_with_two_branches_preserves_other() {
     assert!(test_repo.branch_exists("feature-b"));
 
     // B1 should remain, A1 and A2 should be gone
-    let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
-    let messages: Vec<&str> = info.commits.iter().map(|c| c.message.as_str()).collect();
-    assert!(!messages.contains(&"A1"), "A1 should be gone");
-    assert!(!messages.contains(&"A2"), "A2 should be gone");
-    assert!(messages.contains(&"B1"), "B1 should remain");
+    let messages = test_repo.commit_messages();
+    assert!(!messages.contains(&"A1".to_string()), "A1 should be gone");
+    assert!(!messages.contains(&"A2".to_string()), "A2 should be gone");
+    assert!(messages.contains(&"B1".to_string()), "B1 should remain");
 }
 
 // ── Co-located branch tests (same tip) ───────────────────────────────────
@@ -253,22 +246,21 @@ fn drop_woven_branch_with_two_branches_preserves_other() {
 #[test]
 fn drop_colocated_non_woven_preserves_other_branch_and_commits() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a with a commit
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
     test_repo.commit("A1", "a1.txt");
     test_repo.switch_branch("integration");
 
     // Fast-forward integration to feature-a
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
     test_repo.force_checkout();
 
     // Create feature-b at the same tip as feature-a (co-located)
     let fa_tip = test_repo.get_branch_target("feature-a");
-    git_branch::create(workdir.as_path(), "feature-b", &fa_tip.to_string()).unwrap();
+    test_repo.create_branch_at("feature-b", &fa_tip.to_string());
 
     // Add a commit after so branches are not at HEAD
     test_repo.commit("Int", "int.txt");
@@ -290,31 +282,35 @@ fn drop_colocated_non_woven_preserves_other_branch_and_commits() {
     );
 
     // Commits should still be in history (not dropped)
-    let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
-    let messages: Vec<&str> = info.commits.iter().map(|c| c.message.as_str()).collect();
-    assert!(messages.contains(&"A1"), "A1 should still be in history");
-    assert!(messages.contains(&"Int"), "Int should still be in history");
+    let messages = test_repo.commit_messages();
+    assert!(
+        messages.contains(&"A1".to_string()),
+        "A1 should still be in history"
+    );
+    assert!(
+        messages.contains(&"Int".to_string()),
+        "Int should still be in history"
+    );
 }
 
 #[test]
 fn drop_colocated_woven_preserves_other_branch_and_commits() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a with a commit
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
     test_repo.commit("A1", "a1.txt");
     test_repo.switch_branch("integration");
 
     // Create feature-b at the same tip as feature-a (co-located)
     let fa_tip = test_repo.get_branch_target("feature-a");
-    git_branch::create(workdir.as_path(), "feature-b", &fa_tip.to_string()).unwrap();
+    test_repo.create_branch_at("feature-b", &fa_tip.to_string());
 
     // Add integration commit and weave feature-a (creates merge topology)
     test_repo.commit("Int", "int.txt");
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
 
     // Drop feature-a — feature-b shares the same tip
     let result = super::drop_branch(&test_repo.repo, "feature-a", true);
@@ -333,10 +329,15 @@ fn drop_colocated_woven_preserves_other_branch_and_commits() {
     );
 
     // A1 should still be in history (feature-b still needs it)
-    let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
-    let messages: Vec<&str> = info.commits.iter().map(|c| c.message.as_str()).collect();
-    assert!(messages.contains(&"A1"), "A1 should still be in history");
-    assert!(messages.contains(&"Int"), "Int should still be in history");
+    let messages = test_repo.commit_messages();
+    assert!(
+        messages.contains(&"A1".to_string()),
+        "A1 should still be in history"
+    );
+    assert!(
+        messages.contains(&"Int".to_string()),
+        "Int should still be in history"
+    );
 }
 
 // ── Stacked branch tests ─────────────────────────────────────────────────
@@ -350,24 +351,23 @@ fn drop_stacked_outer_branch_preserves_inner_branch() {
     //
     // Dropping feat2 should keep feat1 and its commit A1.
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feat1 at merge-base with one commit
-    git_branch::create(workdir.as_path(), "feat1", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feat1", &base_oid.to_string());
     test_repo.switch_branch("feat1");
     test_repo.commit("A1", "a1.txt");
     let feat1_tip = test_repo.head_oid();
 
     // Create feat2 stacked on feat1 with one commit
-    git_branch::create(workdir.as_path(), "feat2", &feat1_tip.to_string()).unwrap();
+    test_repo.create_branch_at("feat2", &feat1_tip.to_string());
     test_repo.switch_branch("feat2");
     test_repo.commit("A2", "a2.txt");
     test_repo.switch_branch("integration");
 
     // Add integration commit and weave feat2 (which includes feat1)
     test_repo.commit("Int", "int.txt");
-    git_merge::merge_no_ff(workdir.as_path(), "feat2").unwrap();
+    test_repo.merge_no_ff("feat2");
 
     // Drop feat2
     let result = super::drop_branch(&test_repo.repo, "feat2", true);
@@ -380,11 +380,16 @@ fn drop_stacked_outer_branch_preserves_inner_branch() {
     assert!(test_repo.branch_exists("feat1"), "feat1 should still exist");
 
     // A1 should remain in history, A2 should be gone
-    let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
-    let messages: Vec<&str> = info.commits.iter().map(|c| c.message.as_str()).collect();
-    assert!(messages.contains(&"A1"), "A1 should still be in history");
-    assert!(!messages.contains(&"A2"), "A2 should be gone");
-    assert!(messages.contains(&"Int"), "Int should still be in history");
+    let messages = test_repo.commit_messages();
+    assert!(
+        messages.contains(&"A1".to_string()),
+        "A1 should still be in history"
+    );
+    assert!(!messages.contains(&"A2".to_string()), "A2 should be gone");
+    assert!(
+        messages.contains(&"Int".to_string()),
+        "Int should still be in history"
+    );
 }
 
 // ── Drop via run() (end-to-end) ─────────────────────────────────────────

--- a/src/fold_test.rs
+++ b/src/fold_test.rs
@@ -1,5 +1,4 @@
 use crate::git;
-use crate::git_commands::{self, git_branch, git_commit, git_merge};
 use crate::test_helpers::TestRepo;
 use crate::weave::Weave;
 
@@ -138,20 +137,19 @@ fn fold_file_into_non_head_with_other_changes_autostashed() {
 #[test]
 fn fold_file_into_woven_branch_commit() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature branch with a commit that modifies feature1
-    git_branch::create(workdir.as_path(), "feat1", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feat1", &base_oid.to_string());
     test_repo.switch_branch("feat1");
     test_repo.write_file("feature1", "initial feature content");
-    git_commit::stage_files(workdir.as_path(), &["feature1"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Feature 1").unwrap();
+    test_repo.stage_files(&["feature1"]);
+    test_repo.commit_staged("Feature 1");
     let feat1_oid = test_repo.head_oid();
 
     // Merge feat1 into integration branch
     test_repo.switch_branch("integration");
-    git_merge::merge_no_ff(workdir.as_path(), "feat1").unwrap();
+    test_repo.merge_no_ff("feat1");
 
     // Modify feature1 in the working tree (same file as the commit)
     test_repo.write_file("feature1", "updated feature content");
@@ -177,8 +175,7 @@ fn fold_file_into_woven_branch_commit() {
     assert_eq!(test_repo.read_file("feature1"), "updated feature content");
 
     // There should be no unmerged paths
-    let status_output =
-        git_commands::run_git_stdout(workdir.as_path(), &["status", "--porcelain"]).unwrap();
+    let status_output = test_repo.status_porcelain();
     assert!(
         !status_output.contains("UU") && !status_output.contains("AA"),
         "Working tree should have no merge conflicts, but status shows:\n{}",
@@ -302,8 +299,7 @@ fn fold_commit_to_branch() {
     let a1_oid = test_repo.head_oid();
 
     // Create feature-a branch and weave it
-    let workdir = test_repo.workdir();
-    git_branch::create(workdir.as_path(), "feature-a", &a1_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &a1_oid.to_string());
 
     let base_oid = test_repo.find_remote_branch_target("origin/main");
     // Add a commit on integration line before merge
@@ -311,13 +307,8 @@ fn fold_commit_to_branch() {
 
     // Manually set up merge topology:
     // Rebase B1 onto merge-base, then merge feature-a
-    git_commands::git_rebase::rebase_onto(
-        workdir.as_path(),
-        &base_oid.to_string(),
-        &a1_oid.to_string(),
-    )
-    .unwrap();
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.rebase_onto(&base_oid.to_string(), &a1_oid.to_string());
+    test_repo.merge_no_ff("feature-a");
 
     // Now add a loose commit on the integration line
     test_repo.commit("C1", "c1.txt");
@@ -329,10 +320,8 @@ fn fold_commit_to_branch() {
     assert!(result.is_ok(), "fold_commit_to_branch failed: {:?}", result);
 
     // C1 should now be on feature-a's branch (feature-a tip should have C1's message)
-    let feature_a_oid = test_repo.get_branch_target("feature-a");
-    let feature_a_commit = test_repo.find_commit(feature_a_oid);
     assert_eq!(
-        feature_a_commit.summary().unwrap_or(""),
+        test_repo.branch_commit_summary("feature-a"),
         "C1",
         "C1 should now be at the tip of feature-a"
     );
@@ -342,23 +331,17 @@ fn fold_commit_to_branch() {
 fn fold_commit_to_branch_dirty_autostashed() {
     // Set up an integration branch with a woven feature branch and a loose commit
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
 
     test_repo.commit("A1", "a1.txt");
     let a1_oid = test_repo.head_oid();
 
-    git_branch::create(workdir.as_path(), "feature-a", &a1_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &a1_oid.to_string());
 
     let base_oid = test_repo.find_remote_branch_target("origin/main");
     test_repo.commit("B1", "b1.txt");
 
-    git_commands::git_rebase::rebase_onto(
-        workdir.as_path(),
-        &base_oid.to_string(),
-        &a1_oid.to_string(),
-    )
-    .unwrap();
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.rebase_onto(&base_oid.to_string(), &a1_oid.to_string());
+    test_repo.merge_no_ff("feature-a");
 
     let loose_oid = test_repo.commit("Loose", "loose.txt");
 
@@ -404,11 +387,10 @@ fn fold_commit_to_colocated_branch_only_affects_target() {
     //   ●  Feat1
     //   ╯
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Build the 'test' branch with two commits: Feat1 and Feat3
-    git_branch::create(workdir.as_path(), "test", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("test", &base_oid.to_string());
     test_repo.switch_branch("test");
     test_repo.commit("Feat1", "feat1.txt");
     test_repo.commit("Feat3", "feat3.txt");
@@ -416,20 +398,20 @@ fn fold_commit_to_colocated_branch_only_affects_target() {
     test_repo.switch_branch("integration");
 
     // Weave the 'test' branch
-    git_merge::merge_no_ff(workdir.as_path(), "test").unwrap();
+    test_repo.merge_no_ff("test");
 
     // Build the 'feat2' branch with one commit: Feat2
-    git_branch::create(workdir.as_path(), "feat2", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feat2", &base_oid.to_string());
     test_repo.switch_branch("feat2");
     test_repo.commit("Feat2", "feat2.txt");
     test_repo.switch_branch("integration");
 
     // Create feat3 as co-located with feat2 (same tip)
     let feat2_tip = test_repo.get_branch_target("feat2");
-    git_branch::create(workdir.as_path(), "feat3", &feat2_tip.to_string()).unwrap();
+    test_repo.create_branch_at("feat3", &feat2_tip.to_string());
 
     // Weave feat2 (which also brings in feat3 since they're co-located)
-    git_merge::merge_no_ff(workdir.as_path(), "feat2").unwrap();
+    test_repo.merge_no_ff("feat2");
 
     // Now move the Feat3 commit from 'test' branch to 'feat3' branch
     let result = super::fold_commit_to_branch(&test_repo.repo, &feat3_oid.to_string(), "feat3");
@@ -437,27 +419,24 @@ fn fold_commit_to_colocated_branch_only_affects_target() {
     assert!(result.is_ok(), "fold_commit_to_branch failed: {:?}", result);
 
     // feat3 should have Feat3 at its tip (above feat2)
-    let feat3_tip = test_repo.get_branch_target("feat3");
-    let feat3_commit = test_repo.find_commit(feat3_tip);
     assert_eq!(
-        feat3_commit.summary().unwrap_or(""),
+        test_repo.branch_commit_summary("feat3"),
         "Feat3",
         "feat3 tip should be Feat3"
     );
 
     // feat2 should still have Feat2 at its tip (NOT Feat3)
-    let feat2_tip = test_repo.get_branch_target("feat2");
-    let feat2_commit = test_repo.find_commit(feat2_tip);
     assert_eq!(
-        feat2_commit.summary().unwrap_or(""),
+        test_repo.branch_commit_summary("feat2"),
         "Feat2",
         "feat2 tip should still be Feat2, not Feat3"
     );
 
     // feat3 should be stacked on feat2: feat3's parent should be feat2's tip
+    let feat3_commit = test_repo.find_commit(test_repo.get_branch_target("feat3"));
     assert_eq!(
         feat3_commit.parent_id(0).unwrap(),
-        feat2_tip,
+        test_repo.get_branch_target("feat2"),
         "feat3 should be stacked on feat2"
     );
 
@@ -495,14 +474,13 @@ fn fold_commit_to_empty_branch() {
     //   ●  B1
     //   ╯
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at base (empty branch, not woven)
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
 
     // Create feature-b with two commits
-    git_branch::create(workdir.as_path(), "feature-b", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-b", &base_oid.to_string());
     test_repo.switch_branch("feature-b");
     test_repo.commit("A1", "a1.txt");
     let a1_oid = test_repo.head_oid();
@@ -510,7 +488,7 @@ fn fold_commit_to_empty_branch() {
     test_repo.switch_branch("integration");
 
     // Weave feature-b into the integration line
-    git_merge::merge_no_ff(workdir.as_path(), "feature-b").unwrap();
+    test_repo.merge_no_ff("feature-b");
 
     // Verify feature-a has no section in the graph (it's at base, not woven)
     let graph = Weave::from_repo(&test_repo.repo).unwrap();
@@ -524,17 +502,16 @@ fn fold_commit_to_empty_branch() {
     assert!(result.is_ok(), "fold_commit_to_branch failed: {:?}", result);
 
     // feature-a should now point to a commit with message "A1"
-    let feature_a_tip = test_repo.get_branch_target("feature-a");
-    let feature_a_commit = test_repo.find_commit(feature_a_tip);
     assert_eq!(
-        feature_a_commit.summary().unwrap_or(""),
+        test_repo.branch_commit_summary("feature-a"),
         "A1",
         "feature-a tip should be A1, but branch was not updated (still at base)"
     );
 
     // feature-a should NOT still be at the base
     assert_ne!(
-        feature_a_tip, base_oid,
+        test_repo.get_branch_target("feature-a"),
+        base_oid,
         "feature-a should have moved from the base commit"
     );
 }
@@ -763,13 +740,12 @@ fn fold_unstaged_clean_tree_fails() {
 #[test]
 fn fold_commit_file_to_unstaged_head() {
     let test_repo = TestRepo::new();
-    let workdir = test_repo.workdir();
 
     // Commit has two files (use CLI for consistent index)
     test_repo.write_file("file1.txt", "content1");
     test_repo.write_file("file2.txt", "content2");
-    git_commit::stage_files(workdir.as_path(), &["file1.txt", "file2.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Two files").unwrap();
+    test_repo.stage_files(&["file1.txt", "file2.txt"]);
+    test_repo.commit_staged("Two files");
 
     let head_oid = test_repo.head_oid();
 
@@ -795,19 +771,18 @@ fn fold_commit_file_to_unstaged_head() {
 #[test]
 fn fold_commit_file_to_unstaged_non_head() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
 
     // First commit has two files (use CLI for staging to avoid libgit2 index mismatch)
     test_repo.write_file("file1.txt", "content1");
     test_repo.write_file("file2.txt", "content2");
-    git_commit::stage_files(workdir.as_path(), &["file1.txt", "file2.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Two files").unwrap();
+    test_repo.stage_files(&["file1.txt", "file2.txt"]);
+    test_repo.commit_staged("Two files");
     let c1_oid = test_repo.head_oid();
 
     // Second commit (also via CLI to keep index consistent)
     test_repo.write_file("file3.txt", "content3");
-    git_commit::stage_files(workdir.as_path(), &["file3.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Second commit").unwrap();
+    test_repo.stage_files(&["file3.txt"]);
+    test_repo.commit_staged("Second commit");
 
     let result =
         super::fold_commit_file_to_unstaged(&test_repo.repo, &c1_oid.to_string(), "file1.txt");
@@ -851,19 +826,18 @@ fn fold_commit_file_to_unstaged_no_changes_fails() {
 #[test]
 fn fold_commit_file_to_commit() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
 
     // First commit has two files (use CLI for staging)
     test_repo.write_file("file1.txt", "content1");
     test_repo.write_file("file2.txt", "content2");
-    git_commit::stage_files(workdir.as_path(), &["file1.txt", "file2.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Source commit").unwrap();
+    test_repo.stage_files(&["file1.txt", "file2.txt"]);
+    test_repo.commit_staged("Source commit");
     let source_oid = test_repo.head_oid();
 
     // Second commit (target, also via CLI)
     test_repo.write_file("file3.txt", "content3");
-    git_commit::stage_files(workdir.as_path(), &["file3.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Target commit").unwrap();
+    test_repo.stage_files(&["file3.txt"]);
+    test_repo.commit_staged("Target commit");
     let target_oid = test_repo.head_oid();
 
     let result = super::fold_commit_file_to_commit(
@@ -912,19 +886,18 @@ fn fold_commit_file_to_commit_same_commit_fails() {
 #[test]
 fn fold_commit_file_to_older_commit() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
 
     // C1 (older, target): adds file_a.txt
     test_repo.write_file("file_a.txt", "aaa");
-    git_commit::stage_files(workdir.as_path(), &["file_a.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Add file_a").unwrap();
+    test_repo.stage_files(&["file_a.txt"]);
+    test_repo.commit_staged("Add file_a");
     let c1_oid = test_repo.head_oid();
 
     // C2 (newer, source): adds file_b.txt and modifies file_a.txt
     test_repo.write_file("file_a.txt", "aaa modified");
     test_repo.write_file("file_b.txt", "bbb");
-    git_commit::stage_files(workdir.as_path(), &["file_a.txt", "file_b.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Add file_b and modify file_a").unwrap();
+    test_repo.stage_files(&["file_a.txt", "file_b.txt"]);
+    test_repo.commit_staged("Add file_b and modify file_a");
     let c2_oid = test_repo.head_oid();
 
     // Move file_a.txt changes from C2 (newer) to C1 (older)
@@ -954,8 +927,7 @@ fn fold_commit_file_to_older_commit() {
 
     // Key assertion: C2's diff should NOT contain a reverse change to file_a.txt.
     // Verify by checking that C2's diff only touches file_b.txt.
-    let c2_diff =
-        git_commands::diff_commit(workdir.as_path(), &test_repo.head_oid().to_string()).unwrap();
+    let c2_diff = test_repo.diff_commit(&test_repo.head_oid().to_string());
     assert!(
         !c2_diff.contains("file_a.txt"),
         "C2 should no longer have any changes to file_a.txt, but diff contains:\n{}",
@@ -969,34 +941,28 @@ fn fold_commit_file_to_older_commit() {
 #[test]
 fn fold_commit_file_to_unstaged_stacked_branch() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Build feature-a on its own branch
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
 
     test_repo.write_file("fa1.txt", "feature-a file 1");
     test_repo.write_file("fa2.txt", "feature-a file 2");
-    git_commit::stage_files(workdir.as_path(), &["fa1.txt", "fa2.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "A1: two files").unwrap();
+    test_repo.stage_files(&["fa1.txt", "fa2.txt"]);
+    test_repo.commit_staged("A1: two files");
 
     // Build feature-b stacked on feature-a
-    git_branch::create(
-        workdir.as_path(),
-        "feature-b",
-        &test_repo.head_oid().to_string(),
-    )
-    .unwrap();
+    test_repo.create_branch_at("feature-b", &test_repo.head_oid().to_string());
     test_repo.switch_branch("feature-b");
 
     test_repo.write_file("fb1.txt", "feature-b file 1");
-    git_commit::stage_files(workdir.as_path(), &["fb1.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "B1: one file").unwrap();
+    test_repo.stage_files(&["fb1.txt"]);
+    test_repo.commit_staged("B1: one file");
 
     // Switch to integration and merge feature-b (includes A1 and B1)
     test_repo.switch_branch("integration");
-    git_merge::merge_no_ff(workdir.as_path(), "feature-b").unwrap();
+    test_repo.merge_no_ff("feature-b");
 
     // Verify setup: both branches exist, working tree has all files
     assert!(
@@ -1050,31 +1016,30 @@ fn fold_commit_file_to_unstaged_stacked_branch() {
 #[test]
 fn fold_commit_file_to_commit_stacked_branch() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Build feature-a branch
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
 
     test_repo.write_file("fa1.txt", "feature-a file 1");
-    git_commit::stage_files(workdir.as_path(), &["fa1.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "A1").unwrap();
+    test_repo.stage_files(&["fa1.txt"]);
+    test_repo.commit_staged("A1");
     let a1_oid = test_repo.head_oid();
 
     // Build feature-b stacked on feature-a
-    git_branch::create(workdir.as_path(), "feature-b", &a1_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-b", &a1_oid.to_string());
     test_repo.switch_branch("feature-b");
 
     test_repo.write_file("fb1.txt", "feature-b file 1");
     test_repo.write_file("fb2.txt", "feature-b file 2");
-    git_commit::stage_files(workdir.as_path(), &["fb1.txt", "fb2.txt"]).unwrap();
-    git_commit::commit(workdir.as_path(), "B1").unwrap();
+    test_repo.stage_files(&["fb1.txt", "fb2.txt"]);
+    test_repo.commit_staged("B1");
     let b1_oid = test_repo.head_oid();
 
     // Merge into integration
     test_repo.switch_branch("integration");
-    git_merge::merge_no_ff(workdir.as_path(), "feature-b").unwrap();
+    test_repo.merge_no_ff("feature-b");
 
     // Move fb1.txt from B1 (newer) to A1 (older)
     let result = super::fold_commit_file_to_commit(
@@ -1105,7 +1070,7 @@ fn fold_commit_file_to_commit_stacked_branch() {
 
     // B1 should no longer have fb1.txt changes
     let b_tip = test_repo.get_branch_target("feature-b");
-    let b_diff = git_commands::diff_commit(workdir.as_path(), &b_tip.to_string()).unwrap();
+    let b_diff = test_repo.diff_commit(&b_tip.to_string());
     assert!(
         !b_diff.contains("fb1.txt"),
         "B1 should no longer have fb1.txt changes, but diff contains:\n{}",
@@ -1119,7 +1084,7 @@ fn fold_commit_file_to_commit_stacked_branch() {
     // Key assertion for Bug 1: feature-a's ref should point to the correct
     // commit (the one with fb1.txt included), not the pre-fixup version.
     let a_tip = test_repo.get_branch_target("feature-a");
-    let a_diff = git_commands::diff_commit(workdir.as_path(), &a_tip.to_string()).unwrap();
+    let a_diff = test_repo.diff_commit(&a_tip.to_string());
     assert!(
         a_diff.contains("fb1.txt"),
         "feature-a (A1) should now include fb1.txt, but diff is:\n{}",
@@ -1140,38 +1105,37 @@ fn fold_commit_file_to_commit_stacked_branch() {
 #[test]
 fn fold_commit_file_to_commit_woven_branches() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Build foo1 branch with one commit
-    git_branch::create(workdir.as_path(), "foo1", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("foo1", &base_oid.to_string());
     test_repo.switch_branch("foo1");
     test_repo.write_file("feature1", "feat 1");
-    git_commit::stage_files(workdir.as_path(), &["feature1"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Feature 1").unwrap();
+    test_repo.stage_files(&["feature1"]);
+    test_repo.commit_staged("Feature 1");
     test_repo.switch_branch("integration");
-    git_merge::merge_no_ff(workdir.as_path(), "foo1").unwrap();
+    test_repo.merge_no_ff("foo1");
 
     // Build foo2 branch with one commit (on base, not on integration)
-    git_branch::create(workdir.as_path(), "foo2", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("foo2", &base_oid.to_string());
     test_repo.switch_branch("foo2");
     test_repo.write_file("feature2", "feat 2");
-    git_commit::stage_files(workdir.as_path(), &["feature2"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Feature 2").unwrap();
+    test_repo.stage_files(&["feature2"]);
+    test_repo.commit_staged("Feature 2");
     let foo2_tip = test_repo.head_oid();
 
     // Build foo3 stacked on foo2 with one commit that modifies feature2 and adds feature7
-    git_branch::create(workdir.as_path(), "foo3", &foo2_tip.to_string()).unwrap();
+    test_repo.create_branch_at("foo3", &foo2_tip.to_string());
     test_repo.switch_branch("foo3");
     test_repo.write_file("feature2", "feat 2 updated");
     test_repo.write_file("feature7", "feat 7");
-    git_commit::stage_files(workdir.as_path(), &["feature2", "feature7"]).unwrap();
-    git_commit::commit(workdir.as_path(), "Feature 2 fixup").unwrap();
+    test_repo.stage_files(&["feature2", "feature7"]);
+    test_repo.commit_staged("Feature 2 fixup");
     let foo3_tip = test_repo.head_oid();
 
     // Only merge foo3 into integration (brings in both foo2 and foo3 commits)
     test_repo.switch_branch("integration");
-    git_merge::merge_no_ff(workdir.as_path(), "foo3").unwrap();
+    test_repo.merge_no_ff("foo3");
 
     // Now move 'feature7' from foo3 tip (newer) to foo2 tip (older)
     let result = super::fold_commit_file_to_commit(
@@ -1197,8 +1161,7 @@ fn fold_commit_file_to_commit_woven_branches() {
 
     // foo2's commit should now include feature7
     let foo2_new_tip = test_repo.get_branch_target("foo2");
-    let foo2_diff =
-        git_commands::diff_commit(workdir.as_path(), &foo2_new_tip.to_string()).unwrap();
+    let foo2_diff = test_repo.diff_commit(&foo2_new_tip.to_string());
     assert!(
         foo2_diff.contains("feature7"),
         "foo2 should now include feature7, but diff is:\n{}",
@@ -1207,8 +1170,7 @@ fn fold_commit_file_to_commit_woven_branches() {
 
     // foo3's commit should no longer include feature7
     let foo3_new_tip = test_repo.get_branch_target("foo3");
-    let foo3_diff =
-        git_commands::diff_commit(workdir.as_path(), &foo3_new_tip.to_string()).unwrap();
+    let foo3_diff = test_repo.diff_commit(&foo3_new_tip.to_string());
     assert!(
         !foo3_diff.contains("feature7"),
         "foo3 should no longer include feature7, but diff contains:\n{}",

--- a/src/push_test.rs
+++ b/src/push_test.rs
@@ -1,4 +1,3 @@
-use crate::git_commands::git_branch;
 use crate::test_helpers::TestRepo;
 
 // ── extract_remote_name tests ────────────────────────────────────────────
@@ -43,7 +42,7 @@ fn detect_remote_type_gerrit_by_config() {
     test_repo.commit("C1", "c1.txt");
 
     // Set loom.remote-type to gerrit
-    crate::git_commands::run_git(&workdir, &["config", "loom.remote-type", "gerrit"]).unwrap();
+    test_repo.set_config("loom.remote-type", "gerrit");
 
     let result = super::detect_remote_type(&test_repo.repo, &workdir, "origin/main");
     assert!(result.is_ok());
@@ -62,7 +61,7 @@ fn detect_remote_type_github_by_config() {
     test_repo.commit("C1", "c1.txt");
 
     // Set loom.remote-type to github
-    crate::git_commands::run_git(&workdir, &["config", "loom.remote-type", "github"]).unwrap();
+    test_repo.set_config("loom.remote-type", "github");
 
     let result = super::detect_remote_type(&test_repo.repo, &workdir, "origin/main");
     assert!(result.is_ok());
@@ -77,7 +76,7 @@ fn detect_remote_type_config_overrides_url() {
 
     // Even though remote URL is a local path (not github.com),
     // explicit config should take priority
-    crate::git_commands::run_git(&workdir, &["config", "loom.remote-type", "gerrit"]).unwrap();
+    test_repo.set_config("loom.remote-type", "gerrit");
 
     let result = super::detect_remote_type(&test_repo.repo, &workdir, "origin/main");
     assert!(result.is_ok());
@@ -168,11 +167,10 @@ fn resolve_push_remote_plain_upstream_stays_upstream() {
 #[test]
 fn resolve_branch_accepts_woven_branch() {
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at merge-base
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
 
     // Switch to feature-a, add a commit, switch back
     test_repo.switch_branch("feature-a");
@@ -181,7 +179,7 @@ fn resolve_branch_accepts_woven_branch() {
 
     // Add integration commit + merge to create woven topology
     test_repo.commit("Int", "int.txt");
-    crate::git_commands::git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
 
     let result = super::resolve_branch(
         &test_repo.repo,

--- a/src/split_test.rs
+++ b/src/split_test.rs
@@ -1,5 +1,3 @@
-use crate::git;
-use crate::git_commands::{git_branch, git_merge};
 use crate::test_helpers::TestRepo;
 
 // ── HEAD split tests ──────────────────────────────────────────────────
@@ -11,31 +9,10 @@ fn split_head_commit() {
     test_repo.commit("Add files", "file1.txt");
 
     // Create a commit that touches two files
-    test_repo.write_file("file_a.txt", "content a");
-    test_repo.write_file("file_b.txt", "content b");
-    {
-        let mut index = test_repo.repo.index().unwrap();
-        index.add_path(std::path::Path::new("file_a.txt")).unwrap();
-        index.add_path(std::path::Path::new("file_b.txt")).unwrap();
-        index.write().unwrap();
-        let tree_id = index.write_tree().unwrap();
-        let tree = test_repo.repo.find_tree(tree_id).unwrap();
-        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-        let parent = test_repo.head_commit();
-        test_repo
-            .repo
-            .commit(
-                Some("HEAD"),
-                &sig,
-                &sig,
-                "Two files commit",
-                &tree,
-                &[&parent],
-            )
-            .unwrap();
-    }
-
-    let target_oid = test_repo.head_oid();
+    let target_oid = test_repo.commit_multi(
+        &[("file_a.txt", "content a"), ("file_b.txt", "content b")],
+        "Two files commit",
+    );
 
     let result = super::split_commit_with_selection(
         &test_repo.repo,
@@ -52,11 +29,14 @@ fn split_head_commit() {
     assert_eq!(test_repo.get_message(1), "First part");
 
     // Verify files are in the right commits
-    let head_files = git::commit_file_paths(&test_repo.repo, test_repo.get_oid(0)).unwrap();
-    assert_eq!(head_files, vec!["file_b.txt"]);
-
-    let first_files = git::commit_file_paths(&test_repo.repo, test_repo.get_oid(1)).unwrap();
-    assert_eq!(first_files, vec!["file_a.txt"]);
+    assert_eq!(
+        test_repo.commit_file_paths(test_repo.get_oid(0)),
+        vec!["file_b.txt"]
+    );
+    assert_eq!(
+        test_repo.commit_file_paths(test_repo.get_oid(1)),
+        vec!["file_a.txt"]
+    );
 }
 
 // ── Non-HEAD split tests ──────────────────────────────────────────────
@@ -67,30 +47,10 @@ fn split_non_head_commit() {
     let test_repo = TestRepo::new_with_remote();
 
     // Create a commit with two files
-    test_repo.write_file("file_a.txt", "content a");
-    test_repo.write_file("file_b.txt", "content b");
-    {
-        let mut index = test_repo.repo.index().unwrap();
-        index.add_path(std::path::Path::new("file_a.txt")).unwrap();
-        index.add_path(std::path::Path::new("file_b.txt")).unwrap();
-        index.write().unwrap();
-        let tree_id = index.write_tree().unwrap();
-        let tree = test_repo.repo.find_tree(tree_id).unwrap();
-        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-        let parent = test_repo.head_commit();
-        test_repo
-            .repo
-            .commit(
-                Some("HEAD"),
-                &sig,
-                &sig,
-                "Two files commit",
-                &tree,
-                &[&parent],
-            )
-            .unwrap();
-    }
-    let target_oid = test_repo.head_oid();
+    let target_oid = test_repo.commit_multi(
+        &[("file_a.txt", "content a"), ("file_b.txt", "content b")],
+        "Two files commit",
+    );
 
     // Add another commit on top
     test_repo.commit("Later commit", "later.txt");
@@ -176,23 +136,10 @@ fn split_preserves_other_commits() {
     let c1_oid = test_repo.commit("Before", "before.txt");
 
     // Create a commit with two files
-    test_repo.write_file("file_a.txt", "content a");
-    test_repo.write_file("file_b.txt", "content b");
-    {
-        let mut index = test_repo.repo.index().unwrap();
-        index.add_path(std::path::Path::new("file_a.txt")).unwrap();
-        index.add_path(std::path::Path::new("file_b.txt")).unwrap();
-        index.write().unwrap();
-        let tree_id = index.write_tree().unwrap();
-        let tree = test_repo.repo.find_tree(tree_id).unwrap();
-        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-        let parent = test_repo.head_commit();
-        test_repo
-            .repo
-            .commit(Some("HEAD"), &sig, &sig, "Split me", &tree, &[&parent])
-            .unwrap();
-    }
-    let split_oid = test_repo.head_oid();
+    let split_oid = test_repo.commit_multi(
+        &[("file_a.txt", "content a"), ("file_b.txt", "content b")],
+        "Split me",
+    );
 
     test_repo.commit("After", "after.txt");
 
@@ -223,42 +170,21 @@ fn split_preserves_other_commits() {
 fn split_with_woven_branches() {
     // Verify that split preserves merge topology of woven branches
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at merge-base with a two-file commit
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
 
-    test_repo.write_file("fa1.txt", "content a1");
-    test_repo.write_file("fa2.txt", "content a2");
-    {
-        let mut index = test_repo.repo.index().unwrap();
-        index.add_path(std::path::Path::new("fa1.txt")).unwrap();
-        index.add_path(std::path::Path::new("fa2.txt")).unwrap();
-        index.write().unwrap();
-        let tree_id = index.write_tree().unwrap();
-        let tree = test_repo.repo.find_tree(tree_id).unwrap();
-        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-        let parent = test_repo.head_commit();
-        test_repo
-            .repo
-            .commit(
-                Some("HEAD"),
-                &sig,
-                &sig,
-                "Feature A files",
-                &tree,
-                &[&parent],
-            )
-            .unwrap();
-    }
-    let split_oid = test_repo.head_oid();
+    let split_oid = test_repo.commit_multi(
+        &[("fa1.txt", "content a1"), ("fa2.txt", "content a2")],
+        "Feature A files",
+    );
 
     // Switch back to integration, add a commit, then weave
     test_repo.switch_branch("integration");
     test_repo.commit("Int commit", "int.txt");
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
 
     let result = super::split_commit_with_selection(
         &test_repo.repo,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -509,6 +509,117 @@ impl TestRepo {
             .fetch(&["main"], None, None)
             .unwrap();
     }
+
+    /// Create a branch at a specific commit hash.
+    pub fn create_branch_at(&self, name: &str, commit_hash: &str) {
+        crate::git_commands::git_branch::create(self.workdir().as_path(), name, commit_hash)
+            .unwrap();
+    }
+
+    /// Merge a branch into the current branch with --no-ff.
+    pub fn merge_no_ff(&self, branch: &str) {
+        crate::git_commands::git_merge::merge_no_ff(self.workdir().as_path(), branch).unwrap();
+    }
+
+    /// Stage files in the working directory.
+    pub fn stage_files(&self, files: &[&str]) {
+        crate::git_commands::git_commit::stage_files(self.workdir().as_path(), files).unwrap();
+    }
+
+    /// Commit already-staged files with a message.
+    pub fn commit_staged(&self, message: &str) {
+        crate::git_commands::git_commit::commit(self.workdir().as_path(), message).unwrap();
+    }
+
+    /// Get the names of files that differ from HEAD.
+    pub fn diff_head_name_only(&self) -> String {
+        crate::git_commands::diff_head_name_only(self.workdir().as_path()).unwrap()
+    }
+
+    /// Get the diff of a single commit.
+    pub fn diff_commit(&self, oid: &str) -> String {
+        crate::git_commands::diff_commit(self.workdir().as_path(), oid).unwrap()
+    }
+
+    /// Set a git config value.
+    pub fn set_config(&self, key: &str, value: &str) {
+        crate::git_commands::run_git(self.workdir().as_path(), &["config", key, value]).unwrap();
+    }
+
+    /// Get porcelain status output.
+    pub fn status_porcelain(&self) -> String {
+        crate::git_commands::run_git_stdout(self.workdir().as_path(), &["status", "--porcelain"])
+            .unwrap()
+    }
+
+    /// Rebase commits between `upstream` and HEAD onto `newbase` with --update-refs.
+    pub fn rebase_onto(&self, newbase: &str, upstream: &str) {
+        crate::git_commands::git_rebase::rebase_onto(self.workdir().as_path(), newbase, upstream)
+            .unwrap();
+    }
+
+    /// Get all non-merge commit messages between HEAD and merge-base.
+    pub fn commit_messages(&self) -> Vec<String> {
+        let info = crate::git::gather_repo_info(&self.repo, false, 1).unwrap();
+        info.commits.iter().map(|c| c.message.clone()).collect()
+    }
+
+    /// Get all branch names in the commit range.
+    pub fn branch_names(&self) -> Vec<String> {
+        let info = crate::git::gather_repo_info(&self.repo, false, 1).unwrap();
+        info.branches.iter().map(|b| b.name.clone()).collect()
+    }
+
+    /// Get the commit summary at the tip of a branch.
+    pub fn branch_commit_summary(&self, name: &str) -> String {
+        let oid = self.get_branch_target(name);
+        let commit = self.find_commit(oid);
+        commit.summary().unwrap_or("").to_string()
+    }
+
+    /// Get the file paths changed in a commit.
+    pub fn commit_file_paths(&self, oid: git2::Oid) -> Vec<String> {
+        crate::git::commit_file_paths(&self.repo, oid).unwrap()
+    }
+
+    /// Create a commit touching multiple files at once.
+    ///
+    /// Each entry is a `(filename, content)` pair.  Uses the git2 API
+    /// directly so it stays consistent with the single-file `commit()`.
+    pub fn commit_multi(&self, files: &[(&str, &str)], message: &str) -> git2::Oid {
+        for (filename, content) in files {
+            self.write_file(filename, content);
+        }
+        let mut index = self.repo.index().unwrap();
+        for (filename, _) in files {
+            index.add_path(Path::new(filename)).unwrap();
+        }
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = self.repo.find_tree(tree_id).unwrap();
+        let sig = Self::sig();
+
+        if let Ok(head) = self.repo.head() {
+            let parent = self.repo.find_commit(head.target().unwrap()).unwrap();
+            self.repo
+                .commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
+                .unwrap()
+        } else {
+            self.repo
+                .commit(Some("HEAD"), &sig, &sig, message, &tree, &[])
+                .unwrap()
+        }
+    }
+
+    /// Assert that the working tree is clean (no diff from HEAD).
+    pub fn assert_working_tree_clean(&self) {
+        let diff = self.diff_head_name_only();
+        assert!(
+            diff.trim().is_empty(),
+            "working tree should be clean, but has: {}",
+            diff
+        );
+    }
 }
 
 /// Builder for creating test repositories with a fluent API.

--- a/src/weave_test.rs
+++ b/src/weave_test.rs
@@ -592,15 +592,13 @@ fn from_repo_linear_integration() {
 
 #[test]
 fn from_repo_with_woven_branch() {
-    use crate::git_commands::{git_branch, git_merge};
     use crate::test_helpers::TestRepo;
 
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Create feature-a at merge-base
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
 
     // Switch to feature-a and add commits
     test_repo.switch_branch("feature-a");
@@ -614,7 +612,7 @@ fn from_repo_with_woven_branch() {
     test_repo.commit("Int", "int.txt");
 
     // Merge feature-a
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
 
     let graph = Weave::from_repo(&test_repo.repo).unwrap();
 
@@ -646,18 +644,16 @@ fn from_repo_with_woven_branch() {
 
 #[test]
 fn from_repo_with_non_woven_branch() {
-    use crate::git_commands::git_branch;
     use crate::test_helpers::TestRepo;
 
     let test_repo = TestRepo::new_with_remote();
-    let workdir = test_repo.workdir();
 
     // Add commits on integration
     test_repo.commit("C1", "c1.txt");
     let c1_oid = test_repo.head_oid();
 
     // Create feature-a at C1 (non-woven, just a branch pointing at a commit)
-    git_branch::create(workdir.as_path(), "feature-a", &c1_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &c1_oid.to_string());
 
     test_repo.commit("C2", "c2.txt");
 
@@ -678,7 +674,6 @@ fn from_repo_with_non_woven_branch() {
 
 #[test]
 fn from_repo_round_trip_preserves_identity() {
-    use crate::git_commands::{git_branch, git_merge};
     use crate::test_helpers::TestRepo;
 
     let test_repo = TestRepo::new_with_remote();
@@ -686,12 +681,12 @@ fn from_repo_round_trip_preserves_identity() {
     let base_oid = test_repo.find_remote_branch_target("origin/main");
 
     // Build a non-trivial graph
-    git_branch::create(workdir.as_path(), "feature-a", &base_oid.to_string()).unwrap();
+    test_repo.create_branch_at("feature-a", &base_oid.to_string());
     test_repo.switch_branch("feature-a");
     test_repo.commit("A1", "a1.txt");
     test_repo.switch_branch("integration");
     test_repo.commit("Int", "int.txt");
-    git_merge::merge_no_ff(workdir.as_path(), "feature-a").unwrap();
+    test_repo.merge_no_ff("feature-a");
 
     // Record state before round-trip
     let messages_before: Vec<String> = {


### PR DESCRIPTION
Add stage_files, commit_staged, create_branch_at, merge_no_ff, assert_working_tree_clean, and branch_names to TestRepo, replacing direct git_commands calls across all test files (-143 lines).