### PR TITLE
docs(push): document auto-generated PR title and description

### DIFF
--- a/docs/src/commands/push.md
+++ b/docs/src/commands/push.md
@@ -45,7 +45,7 @@ Uses `--force-with-lease` because woven branches are frequently rebased. `--forc
 Pushes the branch with `--force-with-lease`, then checks whether a PR already exists for the branch:
 
 - **PR exists** — prints the PR URL (`PR updated: https://github.com/owner/repo/pull/42`) without opening the browser
-- **No PR** — opens the GitHub PR creation page in the browser via `gh pr create --web`
+- **No PR** — creates the PR via `gh pr create` with an auto-generated title and description (see [PR Title and Description](#pr-title-and-description) below)
 
 If `gh` is not installed, the push succeeds with a message suggesting to install it.
 
@@ -58,7 +58,7 @@ If the branch being pushed is the upstream target branch itself, PR creation is 
 Pushes the branch with `--force-with-lease`, then checks whether a PR already exists for the branch:
 
 - **PR exists** — prints the PR URL (`PR updated: https://dev.azure.com/...`) without opening the browser
-- **No PR** — opens the Azure DevOps PR creation page in the browser via `az repos pr create --open`
+- **No PR** — creates the PR via `az repos pr create` with an auto-generated title and description (see [PR Title and Description](#pr-title-and-description) below)
 
 `--detect` auto-detects the organization and project from the remote URL. If `az` is not installed, the push succeeds with a message suggesting to install it.
 
@@ -69,6 +69,14 @@ git push -o topic=<branch> <remote> <branch>:refs/for/<target>
 ```
 
 Uses the `refs/for/` refspec and sets the topic to the branch name. After pushing, any review URLs returned by Gerrit are extracted from the remote output and displayed below the success message.
+
+## PR Title and Description
+
+When creating a new PR (GitHub or Azure DevOps), git-loom auto-generates the title and description from the branch's commits:
+
+- **Single commit** — the commit subject becomes the PR title and the commit body becomes the description.
+- **Multiple commits** — you are prompted for a PR title. The description is built by concatenating all commit messages (oldest to newest), separated by `---` dividers.
+- **Empty branch** — the branch name is used as the title with an empty description.
 
 ## Pushing Without a PR or Review
 

--- a/docs/src/guides/pushing.md
+++ b/docs/src/guides/pushing.md
@@ -8,8 +8,8 @@ $ git loom push fa
 
 git-loom detects your remote type automatically and runs the appropriate commands:
 
-- **GitHub** — pushes the branch, then checks if a PR exists. If a PR already exists, prints its URL (`PR updated: https://...`). Otherwise opens the PR creation page in your browser via the [`gh` CLI](https://cli.github.com/).
-- **Azure DevOps** — pushes the branch, then checks if a PR exists. If a PR already exists, prints its URL. Otherwise opens the PR creation page via the [`az` CLI](https://learn.microsoft.com/en-us/cli/azure/).
+- **GitHub** — pushes the branch, then checks if a PR exists. If a PR already exists, prints its URL (`PR updated: https://...`). Otherwise creates a PR via the [`gh` CLI](https://cli.github.com/) with a title and description auto-generated from the branch's commits.
+- **Azure DevOps** — pushes the branch, then checks if a PR exists. If a PR already exists, prints its URL. Otherwise creates a PR via the [`az` CLI](https://learn.microsoft.com/en-us/cli/azure/) with a title and description auto-generated from the branch's commits.
 - **Gerrit** — pushes to `refs/for/<target>` (where `<target>` is your upstream branch, e.g. `main` or `master`) with the branch name as topic. Review URLs from the Gerrit remote are displayed after the push.
 - **Plain Git** — pushes with `--force-with-lease`.
 

--- a/specs/011-push.md
+++ b/specs/011-push.md
@@ -77,8 +77,10 @@ gh pr create --web --head <head> --base <target> --repo <owner/repo>
 Pushes the branch with `--force-with-lease` (same safety as plain), then
 checks whether a PR already exists for the branch using `gh pr list`. If a
 PR exists, prints its URL without opening the browser. If no PR exists,
-opens the GitHub PR creation page in the browser via the `gh` CLI. If `gh`
-is not installed, prints a helpful message with a link to install it.
+creates the PR via the `gh` CLI with an auto-generated title and
+description (see [PR Title and Description](#pr-title-and-description)
+below). If `gh` is not installed, prints a helpful message with a link to
+install it.
 
 **Fork workflow:** When the integration branch tracks `upstream/main` (a fork
 setup), feature branches are pushed to `origin` (the user's fork) instead.
@@ -103,8 +105,10 @@ az repos pr create --open --source-branch <branch> --target-branch <target> --de
 
 Pushes the branch with `--force-with-lease` (same safety as plain), then checks
 whether a PR already exists for the branch using `az repos pr list`. If a PR exists,
-prints its URL without opening the browser. If no PR exists, opens the Azure DevOps
-PR creation page in the browser via the `az` CLI. `--detect` lets the Azure CLI
+prints its URL without opening the browser. If no PR exists, creates the PR
+via the `az` CLI with an auto-generated title and description (see
+[PR Title and Description](#pr-title-and-description) below). `--detect` lets
+the Azure CLI
 auto-detect the organization and project from the repository's remote URL. If `az`
 is not installed, prints a helpful message with a link to install it.
 
@@ -121,6 +125,22 @@ After pushing, stderr from the git push command is captured and scanned for
 review URLs. Lines starting with `remote:` that contain `http://` or `https://`
 are extracted and displayed below the success message as indented continuation
 lines.
+
+## PR Title and Description
+
+When creating a new PR (GitHub or Azure DevOps), git-loom auto-generates
+the title and description from the branch's commits:
+
+- **Single commit**: the commit subject becomes the PR title and the commit
+  body becomes the PR description.
+- **Multiple commits**: the user is prompted for a PR title via an
+  interactive input. The description is built by concatenating all commit
+  messages (oldest to newest), separated by `---` dividers. Each entry
+  includes the commit subject and body.
+- **No commits** (empty branch): the branch name is used as the title with
+  an empty description.
+
+Merge commits in the branch are skipped when gathering commit messages.
 
 ## Branch Selection
 


### PR DESCRIPTION
Update spec 011-push, docs/src/commands/push, and the pushing guide
to describe how PR titles and descriptions are auto-generated from
branch commits for GitHub and Azure DevOps.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>