### PR TITLE
refactor: update warn message and use it for branch deletion

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -88,21 +88,29 @@ fn colorize_backticks(message: &str) -> String {
 }
 
 /// Print a success message with a green checkmark.
+/// Additional lines are treated as hints and prefixed with a blue arrow.
 /// Text between backticks is highlighted in yellow.
 pub fn success(message: &str) {
     let mut lines = message.lines();
     if let Some(first) = lines.next() {
         println!("{} {}", "✓".green(), colorize_backticks(first));
         for line in lines {
-            eprintln!("  {} {}", "›".blue(), colorize_backticks(line));
+            println!("  {} {}", "›".blue(), colorize_backticks(line));
         }
     }
 }
 
 /// Print a warning message with a yellow exclamation mark.
+/// Additional lines are treated as hints and prefixed with a blue arrow.
 /// Text between backticks is highlighted in yellow.
 pub fn warn(message: &str) {
-    println!("{} {}", "!".yellow(), colorize_backticks(message));
+    let mut lines = message.lines();
+    if let Some(first) = lines.next() {
+        println!("{} {}", "!".yellow(), colorize_backticks(first));
+        for line in lines {
+            println!("  {} {}", "›".blue(), colorize_backticks(line));
+        }
+    }
 }
 
 /// Print an error message with a red cross to stderr.

--- a/src/update.rs
+++ b/src/update.rs
@@ -125,7 +125,7 @@ pub fn run(skip_confirm: bool) -> Result<()> {
     // Propose removing local branches whose remote tracking branch was pruned
     let gone = find_branches_with_gone_upstream(&repo, &branch_name)?;
     if !gone.is_empty() {
-        msg::warn(&format!(
+        let mut warn_msg = format!(
             "{} local {} with a gone upstream:",
             gone.len(),
             if gone.len() == 1 {
@@ -133,10 +133,12 @@ pub fn run(skip_confirm: bool) -> Result<()> {
             } else {
                 "branches"
             }
-        ));
+        );
         for name in &gone {
-            println!("  · {}", name);
+            warn_msg.push('\n');
+            warn_msg.push_str(name);
         }
+        msg::warn(&warn_msg);
         let confirmed = skip_confirm
             || msg::confirm(if gone.len() == 1 {
                 "Remove it?"


### PR DESCRIPTION
This is more consistent with the rest of the messages in the app.