### PR TITLE
fix(drop): support filenames, paths, and directories as targets

### DIFF
--- a/src/drop.rs
+++ b/src/drop.rs
@@ -32,9 +32,38 @@ pub fn run(target: String, skip_confirm: bool) -> Result<()> {
     }
 }
 
-/// Drop a file: restore tracked changes, or delete new/untracked files.
+/// Drop a file or directory: restore tracked changes, or delete new/untracked entries.
 fn drop_file(repo: &Repository, path: &str, skip_confirm: bool) -> Result<()> {
     let workdir = git::require_workdir(repo, "drop")?;
+    let full_path = workdir.join(path);
+
+    // Directory — restore tracked changes and clean untracked files inside
+    if full_path.is_dir() {
+        // Check for tracked changes first to pick the right prompt and message
+        let has_tracked = {
+            let mut opts = git2::StatusOptions::new();
+            opts.pathspec(path)
+                .include_untracked(false)
+                .recurse_untracked_dirs(false);
+            let statuses = repo.statuses(Some(&mut opts))?;
+            !statuses.is_empty()
+        };
+        if has_tracked {
+            if !skip_confirm && !msg::confirm(&format!("Discard all changes in `{}`?", path))? {
+                bail!("Cancelled");
+            }
+            git_commands::run_git(workdir, &["restore", "--staged", "--worktree", path])?;
+            git_commands::run_git(workdir, &["clean", "-fd", "--", path])?;
+            msg::success(&format!("Restored `{}`", path));
+        } else {
+            if !skip_confirm && !msg::confirm(&format!("Delete `{}`?", path))? {
+                bail!("Cancelled");
+            }
+            git_commands::run_git(workdir, &["clean", "-fd", "--", path])?;
+            msg::success(&format!("Deleted `{}`", path));
+        }
+        return Ok(());
+    }
 
     let status = repo
         .status_file(std::path::Path::new(path))

--- a/src/drop_test.rs
+++ b/src/drop_test.rs
@@ -480,6 +480,109 @@ fn drop_file_deletes_staged_new_file() {
     );
 }
 
+// ── Drop directory tests ─────────────────────────────────────────────────
+
+#[test]
+fn drop_dir_with_only_untracked_files() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit("Base", "base.txt");
+
+    // Create a directory with only untracked files
+    std::fs::create_dir_all(test_repo.workdir().join("newdir")).unwrap();
+    test_repo.write_file("newdir/a.txt", "aaa");
+    test_repo.write_file("newdir/b.txt", "bbb");
+
+    let result = super::drop_file(&test_repo.repo, "newdir", true);
+    assert!(result.is_ok(), "drop_file (dir) failed: {:?}", result);
+
+    assert!(
+        !test_repo.workdir().join("newdir").exists(),
+        "newdir should be deleted"
+    );
+    assert!(
+        test_repo.status_porcelain().is_empty(),
+        "working tree should be clean"
+    );
+}
+
+#[test]
+fn drop_dir_with_only_tracked_modifications() {
+    let test_repo = TestRepo::new_with_remote();
+
+    // Commit files inside a directory
+    std::fs::create_dir_all(test_repo.workdir().join("src")).unwrap();
+    test_repo.write_file("src/one.txt", "original-one");
+    test_repo.write_file("src/two.txt", "original-two");
+    test_repo.stage_files(&["src/one.txt", "src/two.txt"]);
+    test_repo.commit_staged("Initial src files");
+
+    // Modify both tracked files
+    test_repo.write_file("src/one.txt", "modified-one");
+    test_repo.write_file("src/two.txt", "modified-two");
+
+    let result = super::drop_file(&test_repo.repo, "src", true);
+    assert!(result.is_ok(), "drop_file (dir) failed: {:?}", result);
+
+    assert_eq!(test_repo.read_file("src/one.txt"), "original-one");
+    assert_eq!(test_repo.read_file("src/two.txt"), "original-two");
+    assert!(
+        test_repo.status_porcelain().is_empty(),
+        "working tree should be clean"
+    );
+}
+
+#[test]
+fn drop_dir_with_mixed_tracked_and_untracked() {
+    let test_repo = TestRepo::new_with_remote();
+
+    // Commit a file inside a directory
+    std::fs::create_dir_all(test_repo.workdir().join("mix")).unwrap();
+    test_repo.write_file("mix/tracked.txt", "original");
+    test_repo.stage_files(&["mix/tracked.txt"]);
+    test_repo.commit_staged("Initial mix file");
+
+    // Modify tracked file + add untracked file
+    test_repo.write_file("mix/tracked.txt", "modified");
+    test_repo.write_file("mix/untracked.txt", "new");
+
+    let result = super::drop_file(&test_repo.repo, "mix", true);
+    assert!(result.is_ok(), "drop_file (dir) failed: {:?}", result);
+
+    assert_eq!(test_repo.read_file("mix/tracked.txt"), "original");
+    assert!(
+        !test_repo.workdir().join("mix/untracked.txt").exists(),
+        "untracked file should be deleted"
+    );
+    assert!(
+        test_repo.status_porcelain().is_empty(),
+        "working tree should be clean"
+    );
+}
+
+#[test]
+fn drop_dir_with_staged_new_files() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit("Base", "base.txt");
+
+    // Create and stage new files in a directory
+    std::fs::create_dir_all(test_repo.workdir().join("staged")).unwrap();
+    test_repo.write_file("staged/a.txt", "aaa");
+    test_repo.write_file("staged/b.txt", "bbb");
+    test_repo.stage_files(&["staged/a.txt", "staged/b.txt"]);
+
+    let result = super::drop_file(&test_repo.repo, "staged", true);
+    assert!(result.is_ok(), "drop_file (dir) failed: {:?}", result);
+
+    assert!(
+        !test_repo.workdir().join("staged").exists(),
+        "staged dir should be deleted"
+    );
+    assert!(
+        test_repo.status_porcelain().is_empty(),
+        "working tree should be clean"
+    );
+}
+
 // ── Drop all (zz) tests ─────────────────────────────────────────────────
 
 #[test]

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -325,33 +325,10 @@ fn collect_changed_files(repo: &Repository) -> Result<Vec<String>> {
 
 /// Resolve an argument for the fold command.
 ///
-/// Tries `resolve_target()` first (handles branches, git refs, short IDs).
-/// Falls back to checking if the argument is a filesystem path with changes.
+/// Delegates to `resolve_target()` which handles branches, git refs, short IDs,
+/// filenames, and filesystem paths with changes.
 fn resolve_fold_arg(repo: &Repository, arg: &str) -> Result<Target> {
-    match git::resolve_target(repo, arg) {
-        Ok(target) => Ok(target),
-        Err(resolve_err) => {
-            // Try as a filesystem path with changes
-            if let Some(workdir) = repo.workdir() {
-                let full_path = workdir.join(arg);
-                if full_path.exists() && file_has_changes(repo, arg)? {
-                    return Ok(Target::File(arg.to_string()));
-                }
-            }
-            Err(resolve_err)
-        }
-    }
-}
-
-/// Check if a file has staged or unstaged changes.
-fn file_has_changes(repo: &Repository, path: &str) -> Result<bool> {
-    let mut opts = StatusOptions::new();
-    opts.pathspec(path)
-        .include_untracked(true)
-        .recurse_untracked_dirs(true);
-
-    let statuses = repo.statuses(Some(&mut opts))?;
-    Ok(!statuses.is_empty())
+    git::resolve_target(repo, arg)
 }
 
 /// Fold file changes into a commit (Case 1: File(s) + Commit).
@@ -360,7 +337,7 @@ fn fold_files_into_commit(repo: &Repository, files: &[String], commit_hash: &str
 
     // Validate all files have changes
     for file in files {
-        if !file_has_changes(repo, file)? {
+        if !git::path_has_changes(repo, file)? {
             bail!("File '{}' has no changes to fold", file);
         }
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -387,7 +387,30 @@ pub fn resolve_target(repo: &Repository, target: &str) -> Result<Target> {
 
     // Not a valid git reference - try as shortid
     // This requires building the full graph (needs upstream)
-    resolve_shortid(repo, target)
+    match resolve_shortid(repo, target) {
+        Ok(resolved) => Ok(resolved),
+        Err(shortid_err) => {
+            // Fall back to filesystem path with changes (file or directory)
+            if let Some(workdir) = repo.workdir() {
+                let full_path = workdir.join(target);
+                if full_path.exists() && path_has_changes(repo, target)? {
+                    return Ok(Target::File(target.to_string()));
+                }
+            }
+            Err(shortid_err)
+        }
+    }
+}
+
+/// Check if a path (file or directory) has staged or unstaged changes.
+pub fn path_has_changes(repo: &Repository, path: &str) -> Result<bool> {
+    let mut opts = StatusOptions::new();
+    opts.pathspec(path)
+        .include_untracked(true)
+        .recurse_untracked_dirs(true);
+
+    let statuses = repo.statuses(Some(&mut opts))?;
+    Ok(!statuses.is_empty())
 }
 
 /// Resolve a shortid to a commit, branch, or file by rebuilding the graph.
@@ -419,9 +442,9 @@ fn resolve_shortid(repo: &Repository, shortid: &str) -> Result<Target> {
         }
     }
 
-    // Search for matching shortid in working change files
+    // Search for matching shortid or filename in working change files
     for file in &info.working_changes {
-        if allocator.get_file(&file.path) == shortid {
+        if allocator.get_file(&file.path) == shortid || file.path == shortid {
             return Ok(Target::File(file.path.clone()));
         }
     }


### PR DESCRIPTION
resolve_target now matches working change files by path (not just short
ID) and falls back to filesystem paths with changes. drop_file handles
directories by restoring tracked changes and cleaning untracked files.
Moved the filesystem-path fallback from fold into the shared resolver so
all commands benefit.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>