### PR TITLE
feat(fold): allow folding staged files with single-arg `loom fold <target>`

### DIFF
--- a/docs/src/commands/fold.md
+++ b/docs/src/commands/fold.md
@@ -5,11 +5,12 @@ Fold source(s) into a target — a polymorphic command that amends files into co
 ## Usage
 
 ```
+git-loom fold <target>
 git-loom fold <source>... <target>
 git-loom fold --create <commit> <new-branch>
 ```
 
-The last argument is always the target. All preceding arguments are sources. At least two arguments are required.
+When only a target is given, currently staged files are folded into the target commit. When two or more arguments are provided, the last argument is the target and all preceding arguments are sources.
 
 ## Type Dispatch
 
@@ -17,6 +18,7 @@ The action depends on the types of the arguments, detected automatically:
 
 | Source | Target | Action |
 |--------|--------|--------|
+| *(staged)* | Commit | **Amend staged**: fold currently staged files into the commit |
 | File(s) | Commit | **Amend**: stage files into the commit |
 | `zz` | Commit | **Amend all**: stage all changed files into the commit |
 | Commit | Commit | **Fixup**: absorb source commit into target |
@@ -29,6 +31,18 @@ The action depends on the types of the arguments, detected automatically:
 CommitFile sources use the `commit_sid:index` format shown by `git loom status -f` (e.g. `fa:0` for the first file in commit `fa`).
 
 ## Actions
+
+### Fold staged files into a commit
+
+When only a target is given, staged files are folded into the commit:
+
+```bash
+git add src/auth.rs
+git-loom fold ab
+# Folds staged changes into commit ab
+```
+
+Only files in the git index are folded — unstaged changes to the same files are preserved. Errors with `"Nothing to commit"` if nothing is staged.
 
 ### Amend files into a commit
 

--- a/docs/src/guides/amending.md
+++ b/docs/src/guides/amending.md
@@ -22,6 +22,15 @@ $ git loom fold src/auth.rs d0
 
 This stages `src/auth.rs` and amends it into commit `d0`. The branch topology stays the same — the commit just gains the new changes.
 
+If you've already staged the files you want to amend, you can use the single-argument form:
+
+```bash
+$ git add src/auth.rs
+$ git loom fold d0
+```
+
+This folds only the staged changes — any unstaged modifications to the same files are preserved.
+
 To amend **all** working tree changes into a commit at once:
 
 ```bash

--- a/specs/007-fold.md
+++ b/specs/007-fold.md
@@ -25,19 +25,24 @@ etc.). `fold` unifies them under one verb: **fold source into target**.
 ## CLI
 
 ```bash
+git-loom fold <target>
 git-loom fold <source>... <target>
 git-loom fold --create <commit> <new-branch>
 ```
 
 **Arguments:**
 
-- `<source>...`: One or more sources to fold into the target. Sources can be
-  filenames, commit hashes, partial hashes, short IDs, or branch names.
 - `<target>`: The target to fold into. Can be a commit (hash, partial hash,
   short ID) or a branch name (full name or short ID).
+- `<source>...`: One or more sources to fold into the target. Sources can be
+  filenames, commit hashes, partial hashes, short IDs, or branch names.
 
-The last argument is always the target. All preceding arguments are sources.
-There must be at least two arguments total (one source + one target).
+When only a target is provided (single argument), the currently staged files
+are folded into the target commit. If nothing is staged, an error is returned:
+`"Nothing to commit"`.
+
+When two or more arguments are provided, the last argument is the target and
+all preceding arguments are sources.
 
 **Flags:**
 
@@ -54,6 +59,7 @@ combination:
 
 | Source(s) | Target | Action | Multi-source? |
 |-----------|--------|--------|---------------|
+| *(staged)* | Commit | Amend staged: fold currently staged files into the commit | No |
 | File(s) | Commit | Amend: stage files into the commit | Yes |
 | Unstaged (`zz`) | Commit | Amend all: stage all changed files into the commit | No |
 | Commit | Commit | Fixup: absorb source into target | No |
@@ -68,6 +74,8 @@ CommitFile sources use the `commit_sid:index` format shown by `git loom status -
 
 **Invalid combinations** produce an error:
 
+- Single-arg with nothing staged: `"Nothing to commit"`
+- Single-arg with non-commit target: `"Target must be a commit when folding staged files"`
 - File + Branch: `"Cannot fold files into a branch. Target a specific commit."`
 - Branch + anything: `"Cannot fold a branch. Use 'git loom branch' for branch operations."`
 - Unstaged (`zz`) + non-Commit target: `"Cannot fold files into unstaged — files are already in the working directory."` / `"Cannot fold files into a branch. Target a specific commit."`
@@ -77,6 +85,26 @@ CommitFile sources use the `commit_sid:index` format shown by `git loom status -
 - CommitFile + Branch: `"Cannot fold a commit file into a branch. Target a specific commit or use 'zz' to uncommit."`
 
 ## What Happens
+
+### Case 0: Staged Files + Commit (Single-Argument)
+
+Folds currently staged files into an existing commit. This is the single-argument
+form: `git-loom fold <target>`. Only files in the git index (staged) are folded;
+unstaged changes to the same files are preserved.
+
+**Behavior:**
+
+- The git index must have at least one staged change.
+  Error if nothing staged: `"Nothing to commit"`
+- The target must resolve to a commit.
+  Error if not: `"Target must be a commit when folding staged files"`
+- Works for any commit in history, including HEAD.
+- Unstaged changes (including to the same files) are preserved automatically.
+
+**What changes:**
+
+- The target commit absorbs the staged file changes (new hash)
+- All descendant commits get new hashes (same content/messages)
 
 ### Case 1: File(s) + Commit (Amend)
 
@@ -283,6 +311,14 @@ argument is target).
 - For short ID arguments: must have upstream tracking configured
 
 ## Examples
+
+### Fold staged files into a commit
+
+```bash
+git add src/auth.rs
+git-loom fold ab
+# Folds the staged changes in src/auth.rs into commit ab
+```
 
 ### Amend a file into a commit
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -149,7 +149,7 @@ fn resolve_file_arg(repo: &Repository, workdir: &std::path::Path, arg: &str) -> 
 }
 
 /// Verify that the index has staged changes.
-fn verify_has_staged_changes(repo: &Repository) -> Result<()> {
+pub fn verify_has_staged_changes(repo: &Repository) -> Result<()> {
     let mut opts = StatusOptions::new();
     opts.include_untracked(false);
 

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, bail};
 use git2::{Repository, StatusOptions};
 
+use crate::commit;
 use crate::git::{self, Target};
 use crate::git_commands::{self, git_branch, git_commit, git_rebase};
 use crate::msg;
@@ -19,10 +20,10 @@ const TRACK_BRANCH: &str = "_loom-track";
 ///
 /// With `--create` (`-c`): create a new branch and move the source commit into it.
 pub fn run(create: bool, args: Vec<String>) -> Result<()> {
-    if args.len() < 2 {
+    if args.is_empty() {
         bail!(
-            "At least two arguments required (one source + one target)\n\
-             Usage: git-loom fold <source>... <target>"
+            "At least one argument required\n\
+             Usage: git-loom fold [<source>...] <target>"
         );
     }
 
@@ -30,6 +31,11 @@ pub fn run(create: bool, args: Vec<String>) -> Result<()> {
 
     if create {
         return run_create(&repo, &args);
+    }
+
+    // Single argument: fold staged files into the target commit
+    if args.len() == 1 {
+        return run_staged(&repo, &args[0]);
     }
 
     // Last argument is the target, everything else is a source
@@ -150,6 +156,23 @@ fn create_branch_and_move(
     ));
 
     Ok(())
+}
+
+/// Fold currently staged files into a target commit.
+///
+/// Single-argument form: `loom fold <target>`. The target must resolve to a
+/// commit. If nothing is staged, bails with the same message as `loom commit`.
+fn run_staged(repo: &Repository, target_arg: &str) -> Result<()> {
+    let resolved = resolve_fold_arg(repo, target_arg)?;
+    let commit_hash = match resolved {
+        Target::Commit(hash) => hash,
+        _ => bail!("Target must be a commit when folding staged files"),
+    };
+
+    commit::verify_has_staged_changes(repo)?;
+
+    let staged = git::get_staged_files(repo)?;
+    fold_files_into_commit(repo, &staged, &commit_hash)
 }
 
 /// The classified fold operation.

--- a/src/fold_test.rs
+++ b/src/fold_test.rs
@@ -1373,3 +1373,85 @@ fn fold_create_rejects_non_commit_source() {
         "should error when source is a branch"
     );
 }
+
+// ── Single-arg: Staged files into commit ──────────────────────────────
+
+#[test]
+fn fold_staged_into_head() {
+    let test_repo = TestRepo::new();
+    test_repo.commit("First commit", "file1.txt");
+    test_repo.commit("Second commit", "file2.txt");
+
+    // Modify and stage a file
+    test_repo.write_file("file1.txt", "staged content");
+    test_repo.stage_files(&["file1.txt"]);
+
+    let head_oid = test_repo.head_oid();
+
+    let result = super::run_staged(&test_repo.repo, &head_oid.to_string());
+    assert!(result.is_ok(), "run_staged failed: {:?}", result);
+
+    // HEAD should have been amended
+    assert_eq!(test_repo.get_message(0), "Second commit");
+    assert_ne!(test_repo.head_oid(), head_oid);
+    assert_eq!(test_repo.read_file("file1.txt"), "staged content");
+}
+
+#[test]
+fn fold_staged_nothing_staged_fails() {
+    let test_repo = TestRepo::new();
+    test_repo.commit("First commit", "file1.txt");
+
+    let head_oid = test_repo.head_oid();
+
+    let result = super::run_staged(&test_repo.repo, &head_oid.to_string());
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Nothing to commit"),
+        "should error when nothing is staged"
+    );
+}
+
+#[test]
+fn fold_staged_only_uses_staged_not_unstaged() {
+    let test_repo = TestRepo::new();
+    test_repo.commit("First commit", "file1.txt");
+    test_repo.commit("Second commit", "file2.txt");
+
+    // Stage one file, leave another unstaged
+    test_repo.write_file("file1.txt", "staged content");
+    test_repo.write_file("file2.txt", "unstaged content");
+    test_repo.stage_files(&["file1.txt"]);
+
+    let head_oid = test_repo.head_oid();
+
+    let result = super::run_staged(&test_repo.repo, &head_oid.to_string());
+    assert!(result.is_ok(), "run_staged failed: {:?}", result);
+
+    // Only file1.txt should be in the commit; file2.txt should remain as unstaged
+    assert_eq!(test_repo.read_file("file1.txt"), "staged content");
+    // file2.txt should still have working tree changes (not committed)
+    assert_eq!(test_repo.read_file("file2.txt"), "unstaged content");
+}
+
+#[test]
+fn fold_staged_non_commit_target_fails() {
+    let test_repo = TestRepo::new();
+    test_repo.commit("First commit", "file1.txt");
+
+    test_repo.write_file("file1.txt", "staged content");
+    test_repo.stage_files(&["file1.txt"]);
+
+    // The default branch resolves as a Branch, not a commit
+    let branch_name = test_repo.current_branch_name();
+    let result = super::run_staged(&test_repo.repo, &branch_name);
+    assert!(result.is_err(), "should have failed");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("must be a commit"),
+        "should error when target is not a commit, got: {err_msg}"
+    );
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -413,6 +413,27 @@ pub fn path_has_changes(repo: &Repository, path: &str) -> Result<bool> {
     Ok(!statuses.is_empty())
 }
 
+/// Collect file paths that have staged (index) changes.
+pub fn get_staged_files(repo: &Repository) -> Result<Vec<String>> {
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(false);
+    let statuses = repo.statuses(Some(&mut opts))?;
+    let mut paths = Vec::new();
+    for entry in statuses.iter() {
+        let status = entry.status();
+        if (status.is_index_new()
+            || status.is_index_modified()
+            || status.is_index_deleted()
+            || status.is_index_renamed()
+            || status.is_index_typechange())
+            && let Some(path) = entry.path()
+        {
+            paths.push(path.to_string());
+        }
+    }
+    Ok(paths)
+}
+
 /// Resolve a shortid to a commit, branch, or file by rebuilding the graph.
 fn resolve_shortid(repo: &Repository, shortid: &str) -> Result<Target> {
     // Only gather file info when the shortid looks like a commit-file reference (contains ':')

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ enum Command {
         #[arg(short = 'c', long = "create")]
         create: bool,
         /// Source(s) and target: files, commits, or branches (last arg is the target)
-        #[arg(required = true, num_args = 2..)]
+        #[arg(required = true, num_args = 1..)]
         args: Vec<String>,
     },
     /// Absorb working tree changes into the commits that introduced them


### PR DESCRIPTION
Add a single-argument form that folds currently staged files into the
specified commit. Displays "Nothing to commit" if nothing is staged.
Uses commit::verify_has_staged_changes and git::get_staged_files as
shared utilities, then delegates to existing fold_files_into_commit.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>