### PR TITLE
feat(absorb): absorb chunks instead of full files

### DIFF
--- a/docs/src/commands/absorb.md
+++ b/docs/src/commands/absorb.md
@@ -1,6 +1,6 @@
 # absorb
 
-Automatically distribute working tree changes into the commits that last touched the affected lines. Uses blame to determine the correct target for each file, then amends those commits — all in a single operation.
+Automatically distribute working tree changes into the commits that last touched the affected lines. Uses blame to determine the correct target for each hunk, then amends those commits — all in a single operation.
 
 ## Usage
 
@@ -24,12 +24,13 @@ git-loom absorb [-n] [files...]
 
 For each file with uncommitted changes:
 
-1. Parses the unified diff to find which original lines are modified or deleted
-2. Blames the file at HEAD to determine which commit last touched each original line
-3. If all modified/deleted lines trace to the **same in-scope commit**, the file is assigned to that commit
-4. Otherwise the file is **skipped** with an explanation
+1. Parses the unified diff into individual hunks
+2. For each hunk, blames the modified/deleted lines to find their originating commit
+3. If all hunks trace to the **same in-scope commit**, the whole file is absorbed
+4. If hunks trace to **different commits**, each hunk is independently absorbed into its target
+5. Hunks that can't be attributed (pure additions, ambiguous) are **skipped** and left in the working tree
 
-After analysis, all assigned files are folded into their target commits in a single rebase operation.
+After analysis, all assigned hunks are folded into their target commits in a single rebase operation.
 
 ## Examples
 
@@ -37,25 +38,39 @@ After analysis, all assigned files are folded into their target commits in a sin
 
 ```bash
 git-loom absorb
-# Absorbed 3 files into 2 commits
+#   src/auth.rs -> a1b2c3d "Add authentication"
+#   src/utils.rs -> d4e5f6a "Add utility helpers"
+# Absorbed 2 hunk(s) from 2 file(s) into 2 commit(s)
+```
+
+### Absorb hunks into different commits
+
+```bash
+# src/shared.rs has changes in two separate regions,
+# each originating from a different commit
+git-loom absorb
+#   src/shared.rs [hunk 1/2] -> a1b2c3d "Add login form"
+#   src/shared.rs [hunk 2/2] -> d4e5f6a "Add dashboard"
+# Absorbed 2 hunk(s) from 1 file(s) into 2 commit(s)
 ```
 
 ### Dry run
 
 ```bash
 git-loom absorb --dry-run
-# Would absorb:
-#   src/auth.rs → a1b2c3d "Add authentication"
-#   src/utils.rs → d4e5f6a "Add utility helpers"
-# Skipped:
-#   src/main.rs — modified lines span multiple commits
+#   src/auth.rs -> a1b2c3d "Add authentication"
+#   src/shared.rs [hunk 1/2] -> d4e5f6a "Add utility helpers"
+#   src/shared.rs [hunk 2/2] -- skipped (pure addition)
+# Dry run: would absorb 2 hunk(s) from 2 file(s) into 2 commit(s)
 ```
 
 ### Restrict to specific files
 
 ```bash
 git-loom absorb src/auth.rs src/utils.rs
-# Absorbed 2 files into 1 commit
+#   src/auth.rs -> a1b2c3d "Add authentication"
+#   src/utils.rs -> d4e5f6a "Add utility helpers"
+# Absorbed 2 hunk(s) from 2 file(s) into 2 commit(s)
 ```
 
 ## Prerequisites

--- a/docs/src/guides/absorbing.md
+++ b/docs/src/guides/absorbing.md
@@ -1,25 +1,25 @@
 # Auto-absorbing Changes
 
-You've been tweaking code across several files — fixing a typo in `src/auth.rs`, adjusting a layout in `templates/dashboard.html`. Each file was last touched by a different commit. Instead of manually folding each file, let git-loom figure it out:
+You've been tweaking code across several files — fixing a typo in `src/auth.rs`, adjusting a layout in `templates/dashboard.html`. Each change was last touched by a different commit. Instead of manually folding each one, let git-loom figure it out:
 
 ```bash
 $ git loom absorb
 ```
 
-For each changed file, absorb blames the original lines to find which commit last touched them. If all modified lines trace back to the same commit, the file is automatically folded into it.
+For each changed file, absorb splits the diff into hunks, blames each hunk's original lines to find the originating commit, and folds each hunk into the right place — even when a single file has changes belonging to different commits.
 
 Run a **dry run** first to see what would happen:
 
 ```bash
 $ git loom absorb -n  # or --dry-run
-# Would absorb:
-#   src/auth.rs → d0 "add login form"
-#   templates/dashboard.html → e1 "add dashboard layout"
-# Skipped:
-#   src/main.rs — modified lines span multiple commits
+#   src/auth.rs -> d0 "add login form"
+#   templates/dashboard.html -> e1 "add dashboard layout"
+#   src/shared.rs [hunk 1/2] -> d0 "add login form"
+#   src/shared.rs [hunk 2/2] -- skipped (pure addition)
+# Dry run: would absorb 3 hunk(s) from 3 file(s) into 2 commit(s)
 ```
 
-Files that span multiple commits are skipped — you'll need to handle those manually with `fold`.
+When a file has hunks going to different commits, each hunk is absorbed independently. Hunks that can't be attributed are left in the working tree.
 
 > [!NOTE]
 > Absorb works by blaming existing lines to find their originating commit. It handles modified and deleted lines well, but **newly added lines** (insertions that don't replace existing code) cannot be traced to a commit and will be skipped. Use `fold` for those.

--- a/specs/012-absorb.md
+++ b/specs/012-absorb.md
@@ -4,7 +4,7 @@
 
 `git loom absorb` automatically distributes working tree changes into the
 commits that last touched the affected lines. It uses blame to determine the
-correct target for each file, then amends those commits — all in a single
+correct target for each hunk, then amends those commits — all in a single
 operation.
 
 ## Why Absorb?
@@ -45,20 +45,31 @@ git-loom absorb [--dry-run] [files...]
 
 For each file with uncommitted changes:
 
-1. Parse the unified diff (`git diff HEAD -- <file>`) to find which original
-   lines are modified or deleted. Original lines are the `-` lines in the
-   diff — the lines that existed in HEAD and are being changed.
+1. Parse the unified diff (`git diff HEAD -- <file>`) into individual hunks.
+   Each hunk starts at an `@@ -start,count +start,count @@` header.
 
-2. Blame the file at HEAD to determine which commit last touched each
-   original line.
+2. For each hunk, extract the original (pre-image) line numbers of
+   modified/deleted lines — the `-` lines in the diff.
 
-3. If all modified/deleted original lines trace to the **same commit** and
-   that commit is **in scope** (between merge-base and HEAD), the file is
-   assigned to that commit.
+3. Blame the file at HEAD to determine which commit last touched each
+   modified line in each hunk.
 
-4. Otherwise, the file is **skipped** with an explanation.
+4. Per-hunk assignment:
+   - If all modified lines in a hunk trace to a single **in-scope** commit,
+     the hunk is assigned to that commit.
+   - Otherwise the hunk is **skipped** (pure addition, out of scope,
+     or lines from multiple commits within the hunk).
 
-After analysis, all assigned files are staged and committed as fixup commits,
+5. Per-file result:
+   - If all hunks are assigned to the **same commit**, the entire file is
+     absorbed as a whole (whole-file assignment).
+   - If hunks are assigned to **different commits** (or some are skipped),
+     each assigned hunk is absorbed independently into its target commit.
+     Skipped hunks remain in the working tree.
+   - If **no hunks** can be assigned, the file is skipped entirely.
+
+After analysis, assigned hunks are committed as fixup commits (whole-file
+assignments via `git add`, per-hunk assignments via `git apply --cached`),
 then a single Weave-based rebase folds each fixup into its target.
 
 ### In-Scope Commits
@@ -67,15 +78,15 @@ A commit is "in scope" if it is a non-merge commit between the upstream
 merge-base and HEAD. Commits before the merge-base (from upstream history)
 are out of scope — they cannot be amended via rebase.
 
-### Per-File Assignment
+### Per-Hunk Granularity
 
-In the current version, absorption works at the file level: if all hunks
-in a file trace to the same commit, the entire file is absorbed. If hunks
-trace to different commits, the entire file is skipped.
+Absorption operates at the hunk level. When a file has hunks tracing to
+different commits, each hunk is independently analyzed and absorbed into its
+target commit. Only hunks that cannot be attributed (pure additions, out of
+scope, ambiguous within a single hunk) are left in the working tree.
 
-This handles the vast majority of real-world cases (a file's working-tree
-changes usually relate to a single earlier commit). Per-hunk splitting may
-be added in a future version.
+When all hunks in a file trace to the same commit, the file is absorbed as
+a whole (same as the simpler file-level case).
 
 ## What Happens
 
@@ -99,17 +110,23 @@ are absorbed in a single rebase.
 - Skipped files remain as uncommitted changes in the working tree
 - Other branches not in the ancestry chain
 
-### Skipped Files
+### Skipped Hunks and Files
 
-Files are skipped (left as uncommitted changes) for any of these reasons:
+Individual hunks are skipped (left as uncommitted changes) for these reasons:
+
+| Reason | Description |
+|--------|-------------|
+| Pure addition | Hunk contains only additions (no modified/deleted lines from HEAD) |
+| Multiple sources | Modified lines within a single hunk trace to different commits |
+| Out of scope | Modified lines trace to commits before the merge-base |
+
+Entire files are skipped for these reasons:
 
 | Reason | Description |
 |--------|-------------|
 | New file | File does not exist in HEAD (no blame possible) |
 | Binary file | Binary files cannot be blamed at line level |
-| Multiple sources | Modified lines trace to different commits |
-| Out of scope | Modified lines trace to commits before the merge-base |
-| Pure addition | Diff contains only additions (no modified/deleted lines from HEAD) |
+| All hunks skipped | Every hunk in the file was individually skipped |
 
 ### Dry-Run Mode
 
@@ -118,15 +135,25 @@ commits or running any rebase. The working tree is left unchanged.
 
 ## Output Format
 
-The command prints one line per analyzed file, then a summary:
+The command prints one line per analyzed file (or per hunk for split files),
+then a summary:
 
 ```
   src/auth.rs -> abc1234 "Add login form" (feature-auth)
   src/utils.rs -> def5678 "Add helper functions"
   src/new.rs -- skipped (new file)
-  src/mixed.rs -- skipped (lines from multiple commits)
 
-Absorbed 2 file(s) into 2 commit(s)
+Absorbed 2 hunk(s) from 2 file(s) into 2 commit(s)
+```
+
+For split files (hunks going to different commits):
+
+```
+  src/shared.rs [hunk 1/3] -> abc1234 "Add login form" (feature-auth)
+  src/shared.rs [hunk 2/3] -> def5678 "Add dashboard" (feature-dashboard)
+  src/shared.rs [hunk 3/3] -- skipped (pure addition)
+
+Absorbed 2 hunk(s) from 1 file(s) into 2 commit(s)
 ```
 
 For dry-run:
@@ -135,7 +162,7 @@ For dry-run:
   src/auth.rs -> abc1234 "Add login form" (feature-auth)
   src/utils.rs -> def5678 "Add helper functions"
 
-Dry run: would absorb 2 file(s) into 2 commit(s)
+Dry run: would absorb 2 hunk(s) from 2 file(s) into 2 commit(s)
 ```
 
 When a file's target commit belongs to a feature branch, the branch name is
@@ -173,7 +200,7 @@ git-loom status
 git-loom absorb
 #   src/login.rs -> abc1234 "Add login form" (feature-auth)
 #
-# Absorbed 1 file(s) into 1 commit(s)
+# Absorbed 1 hunk(s) from 1 file(s) into 1 commit(s)
 ```
 
 ### Absorb multiple files into different commits
@@ -187,7 +214,7 @@ git-loom absorb
 #   src/auth.rs -> abc1234 "Add login form"
 #   src/dashboard.rs -> def5678 "Add dashboard"
 #
-# Absorbed 2 file(s) into 2 commit(s)
+# Absorbed 2 hunk(s) from 2 file(s) into 2 commit(s)
 ```
 
 ### Preview with dry-run
@@ -208,23 +235,38 @@ git-loom absorb --dry-run
 git-loom absorb src/auth.rs
 #   src/auth.rs -> abc1234 "Add login form"
 #
-# Absorbed 1 file(s) into 1 commit(s)
+# Absorbed 1 hunk(s) from 1 file(s) into 1 commit(s)
 
 # src/dashboard.rs changes are still in the working tree
 ```
 
-### Skip ambiguous files
+### Absorb hunks from same file into different commits
 
 ```bash
-# src/shared.rs has lines modified by two different commits
+# src/shared.rs has two hunks — one from each commit
+
+git-loom absorb
+#   src/shared.rs [hunk 1/2] -> abc1234 "Add login form"
+#   src/shared.rs [hunk 2/2] -> def5678 "Add dashboard"
+#
+# Absorbed 2 hunk(s) from 1 file(s) into 2 commit(s)
+
+# Each hunk was absorbed into its originating commit
+```
+
+### Skip ambiguous hunks
+
+```bash
+# src/shared.rs has a hunk where lines come from two different commits
 
 git-loom absorb
 #   src/auth.rs -> abc1234 "Add login form"
-#   src/shared.rs -- skipped (lines from multiple commits)
+#   src/shared.rs [hunk 1/2] -> def5678 "Add dashboard"
+#   src/shared.rs [hunk 2/2] -- skipped (lines from multiple commits)
 #
-# Absorbed 1 file(s) into 1 commit(s)
+# Absorbed 2 hunk(s) from 2 file(s) into 2 commit(s)
 
-# src/shared.rs changes remain in the working tree
+# The skipped hunk remains in the working tree
 # Use 'git loom fold src/shared.rs <commit>' to handle manually
 ```
 
@@ -247,7 +289,7 @@ git-loom absorb
 #   src/login.rs -> abc1234 "Add login form" (feature-auth)
 #   src/dashboard.rs -> def5678 "Add dashboard" (feature-dashboard)
 #
-# Absorbed 2 file(s) into 2 commit(s)
+# Absorbed 2 hunk(s) from 2 file(s) into 2 commit(s)
 
 # Branch topology is preserved — merges and branch structure unchanged
 ```
@@ -266,16 +308,20 @@ patch-commutation approach (used by `git-absorb`) because:
 - It integrates cleanly with git2's API (no external dependencies)
 - The per-file simplification makes blame efficient (one blame per file)
 
-### Per-File Granularity (v1)
+### Per-Hunk Granularity
 
-Absorption operates at the file level: either all of a file's changes go to
-one commit, or the file is skipped entirely. This was chosen because:
+Absorption operates at the hunk level: each hunk in a file is independently
+blamed and assigned to its originating commit. This was chosen because:
 
-- It covers the common case (file changes usually trace to one commit)
-- It avoids the complexity of constructing per-hunk patches and handling
-  line-number shifts when applying them sequentially
-- It is safe: no risk of partial or incorrect patch application
-- Per-hunk splitting can be added later as an enhancement
+- It handles the common case where a file has changes spanning multiple
+  earlier commits (e.g. a fix near the top and a fix near the bottom)
+- It follows the approach used by `jj absorb` (Jujutsu)
+- Hunks that cannot be assigned (pure additions, ambiguous) are left in the
+  working tree for the user to handle manually
+
+When all hunks in a file trace to the same commit, the file is absorbed as
+a whole (using `git add` + commit). When hunks trace to different commits,
+per-hunk patches are applied to the index via `git apply --cached`.
 
 ### Fixup Commits + Single Rebase
 
@@ -290,9 +336,9 @@ rebase stops), absorb creates fixup commits at HEAD and uses
 
 ### Automatic Working Tree Preservation
 
-Files that cannot be absorbed remain as uncommitted changes in the working
-tree. The user can then handle them manually with `fold` or address them
-in a subsequent `absorb` after further commits.
+Hunks and files that cannot be absorbed remain as uncommitted changes in the
+working tree. The user can then handle them manually with `fold` or address
+them in a subsequent `absorb` after further commits.
 
 ### Atomic Operations
 

--- a/src/absorb.rs
+++ b/src/absorb.rs
@@ -9,11 +9,23 @@ use crate::git_commands::{self, git_commit};
 use crate::msg;
 use crate::weave::{self, Weave};
 
+/// Per-hunk analysis result.
+enum HunkAnalysis {
+    /// Hunk assigned to a specific in-scope commit.
+    Assigned { commit_oid: Oid },
+    /// Hunk skipped with a reason.
+    Skipped { reason: String },
+}
+
 /// Result of analyzing a single file.
 enum FileAnalysis {
-    /// File assigned to a specific in-scope commit.
+    /// All hunks assigned to the same commit (whole-file absorb).
     Assigned { commit_oid: Oid },
-    /// File skipped with a reason.
+    /// Hunks split across multiple targets or some skipped.
+    Split {
+        hunks: Vec<(DiffHunk, HunkAnalysis)>,
+    },
+    /// Entire file skipped.
     Skipped { reason: String },
 }
 
@@ -39,47 +51,93 @@ pub fn run(dry_run: bool, user_files: Vec<String>) -> Result<()> {
     // Build Weave for branch name lookup in output
     let weave_graph = Weave::from_repo_with_info(&repo, &info)?;
 
-    // Analyze each file
-    let mut assigned: Vec<(String, Oid)> = Vec::new();
-    let mut skipped: Vec<(String, String)> = Vec::new();
+    // Analyze each file — collect assignments at hunk level
+    let mut whole_file_assigned: Vec<(String, Oid)> = Vec::new();
+    let mut hunk_assigned: Vec<(String, Oid, Vec<DiffHunk>)> = Vec::new();
+    let mut skipped_files: Vec<String> = Vec::new();
+    let mut any_assigned = false;
 
     for file in &changed_files {
         match analyze_file(&repo, workdir, file, &in_scope)? {
             FileAnalysis::Assigned { commit_oid } => {
-                assigned.push((file.clone(), commit_oid));
+                print_assignment(file, commit_oid, &in_scope, &weave_graph);
+                whole_file_assigned.push((file.clone(), commit_oid));
+                any_assigned = true;
+            }
+            FileAnalysis::Split { hunks } => {
+                let total = hunks.len();
+                let mut per_commit: HashMap<Oid, Vec<DiffHunk>> = HashMap::new();
+                let mut has_skipped = false;
+
+                for (i, (hunk, analysis)) in hunks.into_iter().enumerate() {
+                    match analysis {
+                        HunkAnalysis::Assigned { commit_oid } => {
+                            print_hunk_assignment(
+                                file,
+                                i + 1,
+                                total,
+                                commit_oid,
+                                &in_scope,
+                                &weave_graph,
+                            );
+                            per_commit.entry(commit_oid).or_default().push(hunk);
+                        }
+                        HunkAnalysis::Skipped { reason } => {
+                            println!(
+                                "  {} [hunk {}/{}] -- skipped ({})",
+                                file,
+                                i + 1,
+                                total,
+                                reason
+                            );
+                            has_skipped = true;
+                        }
+                    }
+                }
+
+                if has_skipped {
+                    skipped_files.push(file.clone());
+                }
+
+                for (oid, hunks_for_commit) in per_commit {
+                    any_assigned = true;
+                    hunk_assigned.push((file.clone(), oid, hunks_for_commit));
+                }
             }
             FileAnalysis::Skipped { reason } => {
-                skipped.push((file.clone(), reason));
+                println!("  {} -- skipped ({})", file, reason);
+                skipped_files.push(file.clone());
             }
         }
     }
 
-    // Print per-file output
-    for (file, oid) in &assigned {
-        let oid_str = oid.to_string();
-        let short = git_commands::short_hash(&oid_str);
-        let message = in_scope.get(oid).map(|c| c.message.as_str()).unwrap_or("");
-        let branch_info = find_branch_for_commit(&weave_graph, *oid)
-            .map(|b| format!(" ({})", b))
-            .unwrap_or_default();
-        println!("  {} -> {} \"{}\"{}", file, short, message, branch_info);
-    }
-    for (file, reason) in &skipped {
-        println!("  {} -- skipped ({})", file, reason);
-    }
-
-    if assigned.is_empty() {
+    if !any_assigned {
         bail!("No files could be absorbed");
     }
 
-    let num_files = assigned.len();
-    let unique_targets: HashSet<Oid> = assigned.iter().map(|(_, oid)| *oid).collect();
+    // Count stats
+    let num_hunks: usize = whole_file_assigned.len()
+        + hunk_assigned
+            .iter()
+            .map(|(_, _, hunks)| hunks.len())
+            .sum::<usize>();
+    let mut unique_targets: HashSet<Oid> = HashSet::new();
+    let mut assigned_file_set: HashSet<&str> = HashSet::new();
+    for (f, oid) in &whole_file_assigned {
+        unique_targets.insert(*oid);
+        assigned_file_set.insert(f.as_str());
+    }
+    for (f, oid, _) in &hunk_assigned {
+        unique_targets.insert(*oid);
+        assigned_file_set.insert(f.as_str());
+    }
     let num_commits = unique_targets.len();
+    let num_files = assigned_file_set.len();
 
     if dry_run {
         println!(
-            "\nDry run: would absorb {} file(s) into {} commit(s)",
-            num_files, num_commits
+            "\nDry run: would absorb {} hunk(s) from {} file(s) into {} commit(s)",
+            num_hunks, num_files, num_commits
         );
         return Ok(());
     }
@@ -88,23 +146,44 @@ pub fn run(dry_run: bool, user_files: Vec<String>) -> Result<()> {
     let saved_head = git::head_oid(&repo)?.to_string();
     let saved_refs = git::snapshot_branch_refs(&repo)?;
 
-    // Group assigned files by target commit
+    // Group whole-file assignments by target commit
     let mut groups: HashMap<Oid, Vec<String>> = HashMap::new();
-    for (file, oid) in &assigned {
+    for (file, oid) in &whole_file_assigned {
         groups.entry(*oid).or_default().push(file.clone());
     }
 
-    // Create fixup commits for each group
-    let mut fixup_pairs: Vec<(Oid, Oid)> = Vec::new(); // (fixup_oid, target_oid)
+    // Group hunk assignments by target commit
+    let mut hunk_groups: HashMap<Oid, Vec<(String, Vec<DiffHunk>)>> = HashMap::new();
+    for (path, oid, hunks) in hunk_assigned {
+        hunk_groups.entry(oid).or_default().push((path, hunks));
+    }
 
+    // Snapshot full working-tree diff before any mutations, for rollback
+    let saved_worktree_patch = git_commands::run_git_stdout(workdir, &["diff", "HEAD"])?;
+
+    let rollback = |warn_patch_err: bool| {
+        let _ = git_commit::reset_hard(workdir, &saved_head);
+        let _ = git::restore_branch_refs(workdir, &saved_refs);
+        if !saved_worktree_patch.is_empty()
+            && let Err(e) = git_commands::apply_patch(workdir, &saved_worktree_patch)
+            && warn_patch_err
+        {
+            eprintln!("Warning: could not restore working tree changes: {}", e);
+        }
+    };
+
+    let mut fixup_pairs: Vec<(Oid, Oid)> = Vec::new();
+
+    // Create fixup commits for whole-file groups
     for (target_oid, files) in &groups {
         let file_refs: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
-        git_commit::stage_files(workdir, &file_refs)?;
+        if let Err(e) = git_commit::stage_files(workdir, &file_refs) {
+            rollback(false);
+            return Err(e);
+        }
         let msg = format!("fixup! absorb into {}", target_oid);
         if let Err(e) = git_commit::commit(workdir, &msg) {
-            // Rollback: unstage and bail
-            let _ = git_commit::reset_hard(workdir, &saved_head);
-            let _ = git::restore_branch_refs(workdir, &saved_refs);
+            rollback(false);
             return Err(e);
         }
         let repo2 = Repository::discover(workdir)?;
@@ -112,15 +191,35 @@ pub fn run(dry_run: bool, user_files: Vec<String>) -> Result<()> {
         fixup_pairs.push((fixup_oid, *target_oid));
     }
 
-    // Save diffs of skipped files and restore them to HEAD before rebase.
-    // This prevents autostash conflicts when the rebase rewrites history.
-    let skipped_files: Vec<&str> = skipped.iter().map(|(f, _)| f.as_str()).collect();
-    let skipped_patch = if !skipped_files.is_empty() {
-        let patch = git_commands::diff_head_name_only(workdir)?;
-        if !patch.trim().is_empty() {
-            // There are still dirty files (the skipped ones) — save their full diff
-            let full_patch = git_commands::run_git_stdout(workdir, &["diff", "HEAD"])?;
-            let _ = git_commands::restore_files_to_head(workdir, &skipped_files);
+    // Create fixup commits for hunk groups
+    for (target_oid, file_hunks) in &hunk_groups {
+        let mut combined_patch = String::new();
+        for (path, hunks) in file_hunks {
+            combined_patch.push_str(&build_hunk_patch(path, hunks));
+        }
+        if let Err(e) = git_commands::apply_cached_patch(workdir, &combined_patch) {
+            rollback(false);
+            return Err(e);
+        }
+        let msg = format!("fixup! absorb into {}", target_oid);
+        if let Err(e) = git_commit::commit(workdir, &msg) {
+            rollback(false);
+            return Err(e);
+        }
+        let repo2 = Repository::discover(workdir)?;
+        let fixup_oid = git::head_oid(&repo2)?;
+        fixup_pairs.push((fixup_oid, *target_oid));
+    }
+
+    // Save diffs of skipped content and restore working tree before rebase
+    let skipped_file_refs: Vec<&str> = skipped_files.iter().map(|f| f.as_str()).collect();
+    let skipped_patch = if !skipped_file_refs.is_empty() {
+        let dirty = git_commands::diff_head_name_only(workdir)?;
+        if !dirty.trim().is_empty() {
+            let mut diff_args: Vec<&str> = vec!["diff", "HEAD", "--"];
+            diff_args.extend(skipped_file_refs.iter().copied());
+            let full_patch = git_commands::run_git_stdout(workdir, &diff_args)?;
+            let _ = git_commands::restore_files_to_head(workdir, &skipped_file_refs);
             Some(full_patch)
         } else {
             None
@@ -138,26 +237,73 @@ pub fn run(dry_run: bool, user_files: Vec<String>) -> Result<()> {
 
     let todo = graph.to_todo();
     if let Err(e) = weave::run_rebase(workdir, Some(&graph.base_oid.to_string()), &todo) {
-        let _ = git_commit::reset_hard(workdir, &saved_head);
-        let _ = git::restore_branch_refs(workdir, &saved_refs);
-        // Try to restore skipped file changes
-        if let Some(ref patch) = skipped_patch {
-            let _ = git_commands::apply_patch(workdir, patch);
-        }
+        rollback(true);
         return Err(e);
     }
 
-    // Re-apply skipped file changes to the working tree
-    if let Some(ref patch) = skipped_patch {
-        let _ = git_commands::apply_patch(workdir, patch);
+    // Re-apply skipped changes to the working tree
+    if let Some(ref patch) = skipped_patch
+        && let Err(e) = git_commands::apply_patch(workdir, patch)
+    {
+        eprintln!("Warning: could not re-apply skipped changes: {}", e);
     }
 
     msg::success(&format!(
-        "Absorbed {} file(s) into {} commit(s)",
-        num_files, num_commits
+        "Absorbed {} hunk(s) from {} file(s) into {} commit(s)",
+        num_hunks, num_files, num_commits
     ));
 
     Ok(())
+}
+
+/// Format a commit target label: `abc1234 "message" (branch)`.
+fn commit_label(
+    commit_oid: Oid,
+    in_scope: &HashMap<Oid, &CommitInfo>,
+    weave_graph: &Weave,
+) -> String {
+    let oid_str = commit_oid.to_string();
+    let short = git_commands::short_hash(&oid_str);
+    let message = in_scope
+        .get(&commit_oid)
+        .map(|c| c.message.as_str())
+        .unwrap_or("");
+    let branch_info = find_branch_for_commit(weave_graph, commit_oid)
+        .map(|b| format!(" ({})", b))
+        .unwrap_or_default();
+    format!("{} \"{}\"{}", short, message, branch_info)
+}
+
+/// Print a whole-file assignment line.
+fn print_assignment(
+    file: &str,
+    commit_oid: Oid,
+    in_scope: &HashMap<Oid, &CommitInfo>,
+    weave_graph: &Weave,
+) {
+    println!(
+        "  {} -> {}",
+        file,
+        commit_label(commit_oid, in_scope, weave_graph)
+    );
+}
+
+/// Print a hunk-level assignment line.
+fn print_hunk_assignment(
+    file: &str,
+    hunk_num: usize,
+    total: usize,
+    commit_oid: Oid,
+    in_scope: &HashMap<Oid, &CommitInfo>,
+    weave_graph: &Weave,
+) {
+    println!(
+        "  {} [hunk {}/{}] -> {}",
+        file,
+        hunk_num,
+        total,
+        commit_label(commit_oid, in_scope, weave_graph)
+    );
 }
 
 /// Determine the list of changed files to analyze.
@@ -215,14 +361,13 @@ fn resolve_file_arg(repo: &Repository, workdir: &Path, arg: &str) -> Result<Stri
     }
 }
 
-/// Analyze a single file to determine which commit it should be absorbed into.
+/// Analyze a single file to determine which commit(s) its hunks should be absorbed into.
 fn analyze_file(
     repo: &Repository,
     workdir: &Path,
     path: &str,
     in_scope: &HashMap<Oid, &CommitInfo>,
 ) -> Result<FileAnalysis> {
-    // Get the diff for this file
     let diff = git_commands::diff_head_file(workdir, path)?;
 
     if diff.is_empty() {
@@ -231,23 +376,27 @@ fn analyze_file(
         });
     }
 
-    // Check for binary files
     if diff.contains("Binary files") {
         return Ok(FileAnalysis::Skipped {
             reason: "binary file".to_string(),
         });
     }
 
-    // Parse modified original line numbers from the diff
-    let modified_lines = parse_modified_lines(&diff);
+    let hunks = parse_hunks(&diff);
 
-    if modified_lines.is_empty() {
+    if hunks.is_empty() {
+        return Ok(FileAnalysis::Skipped {
+            reason: "no hunks".to_string(),
+        });
+    }
+
+    // Check if all hunks are pure additions
+    if hunks.iter().all(|h| h.modified_lines.is_empty()) {
         return Ok(FileAnalysis::Skipped {
             reason: "pure addition".to_string(),
         });
     }
 
-    // Blame the file at HEAD to find which commit owns each modified line
     let blame = match repo.blame_file(std::path::Path::new(path), None) {
         Ok(b) => b,
         Err(_) => {
@@ -257,75 +406,183 @@ fn analyze_file(
         }
     };
 
-    let mut source_commits: HashSet<Oid> = HashSet::new();
+    let analyzed: Vec<(DiffHunk, HunkAnalysis)> = hunks
+        .into_iter()
+        .map(|h| {
+            let analysis = analyze_hunk(&blame, &h, in_scope);
+            (h, analysis)
+        })
+        .collect();
 
-    for &line_no in &modified_lines {
-        if let Some(hunk) = blame.get_line(line_no) {
-            source_commits.insert(hunk.final_commit_id());
+    // Collect unique assigned commits
+    let assigned_oids: HashSet<Oid> = analyzed
+        .iter()
+        .filter_map(|(_, a)| match a {
+            HunkAnalysis::Assigned { commit_oid } => Some(*commit_oid),
+            _ => None,
+        })
+        .collect();
+
+    if assigned_oids.is_empty() {
+        // All hunks skipped — pick the first skip reason
+        let reason = analyzed
+            .first()
+            .map(|(_, a)| match a {
+                HunkAnalysis::Skipped { reason } => reason.clone(),
+                _ => "unknown".to_string(),
+            })
+            .unwrap_or_else(|| "unknown".to_string());
+        return Ok(FileAnalysis::Skipped { reason });
+    }
+
+    if assigned_oids.len() == 1 {
+        let has_skipped = analyzed
+            .iter()
+            .any(|(_, a)| matches!(a, HunkAnalysis::Skipped { .. }));
+        if !has_skipped {
+            // All hunks go to the same commit — whole-file assignment
+            return Ok(FileAnalysis::Assigned {
+                commit_oid: *assigned_oids.iter().next().unwrap(),
+            });
+        }
+    }
+
+    // Multiple targets or mix of assigned/skipped — split
+    Ok(FileAnalysis::Split { hunks: analyzed })
+}
+
+/// Analyze a single diff hunk to determine which commit it should be absorbed into.
+fn analyze_hunk(
+    blame: &git2::Blame<'_>,
+    hunk: &DiffHunk,
+    in_scope: &HashMap<Oid, &CommitInfo>,
+) -> HunkAnalysis {
+    if hunk.modified_lines.is_empty() {
+        return HunkAnalysis::Skipped {
+            reason: "pure addition".to_string(),
+        };
+    }
+
+    let mut source_commits: HashSet<Oid> = HashSet::new();
+    for &line_no in &hunk.modified_lines {
+        if let Some(blame_hunk) = blame.get_line(line_no) {
+            source_commits.insert(blame_hunk.final_commit_id());
         }
     }
 
     if source_commits.len() > 1 {
-        return Ok(FileAnalysis::Skipped {
+        return HunkAnalysis::Skipped {
             reason: "lines from multiple commits".to_string(),
-        });
+        };
     }
 
     let commit_oid = match source_commits.into_iter().next() {
         Some(oid) => oid,
         None => {
-            return Ok(FileAnalysis::Skipped {
+            return HunkAnalysis::Skipped {
                 reason: "no blame data".to_string(),
-            });
+            };
         }
     };
 
-    // Check if the commit is in scope
     if !in_scope.contains_key(&commit_oid) {
-        return Ok(FileAnalysis::Skipped {
+        return HunkAnalysis::Skipped {
             reason: "out of scope".to_string(),
-        });
+        };
     }
 
-    Ok(FileAnalysis::Assigned { commit_oid })
+    HunkAnalysis::Assigned { commit_oid }
 }
 
-/// Parse a unified diff to extract the original line numbers of modified/deleted lines.
+/// A single hunk extracted from a unified diff.
+struct DiffHunk {
+    /// The raw diff text for this hunk (starting with the @@ header, ending before the next hunk
+    /// or EOF).
+    text: String,
+    /// Original (pre-image) line numbers of modified/deleted lines in this hunk.
+    modified_lines: Vec<usize>,
+}
+
+/// Parse a unified diff into individual hunks.
 ///
-/// Looks for `-` lines (lines removed from the original) and maps them back to
-/// their original line numbers using hunk headers (`@@ -start,count ... @@`).
-fn parse_modified_lines(diff: &str) -> Vec<usize> {
-    let mut result = Vec::new();
+/// Each hunk starts at an `@@ -start,count +start,count @@` header and extends
+/// until the next hunk header or end of input. The file headers (`--- a/` / `+++ b/`)
+/// are excluded from hunk text.
+fn parse_hunks(diff: &str) -> Vec<DiffHunk> {
+    let mut hunks: Vec<DiffHunk> = Vec::new();
+    let mut current_text = String::new();
+    let mut current_modified: Vec<usize> = Vec::new();
     let mut current_orig_line: usize = 0;
+    let mut in_hunk = false;
 
     for line in diff.lines() {
-        if let Some(start) = parse_hunk_header(line) {
-            current_orig_line = start;
-        } else if let Some(rest) = line.strip_prefix('-') {
-            // A removed line (but not a file header like "--- a/file")
-            if !rest.starts_with("-- ") {
-                result.push(current_orig_line);
+        if line.starts_with("@@ -") {
+            // Save previous hunk if any
+            if in_hunk {
+                hunks.push(DiffHunk {
+                    text: std::mem::take(&mut current_text),
+                    modified_lines: std::mem::take(&mut current_modified),
+                });
             }
+            // Start new hunk
+            current_text = format!("{}\n", line);
+            current_modified = Vec::new();
+            current_orig_line = parse_hunk_start(line).unwrap_or(1);
+            in_hunk = true;
+        } else if !in_hunk {
+            // File header lines (--- a/, +++ b/, diff --git, etc.) — skip
+            continue;
+        } else if line.starts_with('-') {
+            current_text.push_str(line);
+            current_text.push('\n');
+            current_modified.push(current_orig_line);
             current_orig_line += 1;
         } else if line.starts_with('+') {
+            current_text.push_str(line);
+            current_text.push('\n');
             // Added line — doesn't consume an original line number
-        } else if !line.starts_with('\\') {
-            // Context line — advances original line counter
+        } else if line.starts_with('\\') {
+            current_text.push_str(line);
+            current_text.push('\n');
+            // "\ No newline at end of file" — no line number change
+        } else {
+            // Context line
+            current_text.push_str(line);
+            current_text.push('\n');
             current_orig_line += 1;
         }
     }
 
-    result
+    // Save last hunk
+    if in_hunk {
+        hunks.push(DiffHunk {
+            text: current_text,
+            modified_lines: current_modified,
+        });
+    }
+
+    hunks
 }
 
-/// Parse a hunk header line to extract the starting line number of the original side.
-///
-/// Format: `@@ -start,count +new_start,new_count @@`
-/// Returns the `start` value.
-fn parse_hunk_header(line: &str) -> Option<usize> {
+/// Parse a hunk header to extract the starting line number of the original side.
+fn parse_hunk_start(line: &str) -> Option<usize> {
     let line = line.strip_prefix("@@ -")?;
     let end = line.find([',', ' '])?;
     line[..end].parse().ok()
+}
+
+/// Build a valid unified patch for `git apply` from selected hunks of a single file.
+///
+/// Produces a patch with one file header (`--- a/` / `+++ b/`) followed by
+/// the raw text of each hunk (which includes the `@@` header).
+fn build_hunk_patch(path: &str, hunks: &[DiffHunk]) -> String {
+    let mut patch = String::new();
+    patch.push_str(&format!("--- a/{}\n", path));
+    patch.push_str(&format!("+++ b/{}\n", path));
+    for hunk in hunks {
+        patch.push_str(&hunk.text);
+    }
+    patch
 }
 
 /// Find the branch name that contains a given commit OID in the Weave graph.

--- a/src/absorb_test.rs
+++ b/src/absorb_test.rs
@@ -3,15 +3,7 @@ use crate::test_helpers::TestRepo;
 // ── Unit tests for diff parsing ──────────────────────────────────────
 
 #[test]
-fn parse_hunk_header_basic() {
-    assert_eq!(super::parse_hunk_header("@@ -10,5 +10,7 @@"), Some(10));
-    assert_eq!(super::parse_hunk_header("@@ -1,3 +1,3 @@"), Some(1));
-    assert_eq!(super::parse_hunk_header("@@ -42 +42 @@"), Some(42));
-    assert_eq!(super::parse_hunk_header("not a header"), None);
-}
-
-#[test]
-fn parse_modified_lines_basic() {
+fn parse_hunks_single_hunk() {
     let diff = "\
 --- a/file.txt
 +++ b/file.txt
@@ -21,12 +13,37 @@ fn parse_modified_lines_basic() {
 +new line
  context
 ";
-    let lines = super::parse_modified_lines(diff);
-    assert_eq!(lines, vec![4]); // line 4 in the original was modified
+    let hunks = super::parse_hunks(diff);
+    assert_eq!(hunks.len(), 1);
+    assert_eq!(hunks[0].modified_lines, vec![4]);
+    assert!(hunks[0].text.contains("@@ -3,4 +3,4 @@"));
+    assert!(hunks[0].text.contains("-old line"));
 }
 
 #[test]
-fn parse_modified_lines_pure_addition() {
+fn parse_hunks_multiple_hunks() {
+    let diff = "\
+--- a/file.txt
++++ b/file.txt
+@@ -3,4 +3,4 @@
+ context
+-old line 1
++new line 1
+ context
+@@ -20,4 +20,4 @@
+ context
+-old line 2
++new line 2
+ context
+";
+    let hunks = super::parse_hunks(diff);
+    assert_eq!(hunks.len(), 2);
+    assert_eq!(hunks[0].modified_lines, vec![4]);
+    assert_eq!(hunks[1].modified_lines, vec![21]);
+}
+
+#[test]
+fn parse_hunks_pure_addition() {
     let diff = "\
 --- a/file.txt
 +++ b/file.txt
@@ -36,10 +53,62 @@ fn parse_modified_lines_pure_addition() {
 +added line 2
  context
 ";
-    let lines = super::parse_modified_lines(diff);
+    let hunks = super::parse_hunks(diff);
+    assert_eq!(hunks.len(), 1);
     assert!(
-        lines.is_empty(),
+        hunks[0].modified_lines.is_empty(),
         "pure additions should produce no modified original lines"
+    );
+}
+
+// ── Unit tests for patch construction ────────────────────────────────
+
+#[test]
+fn build_hunk_patch_single_hunk() {
+    let hunk = super::DiffHunk {
+        text: "@@ -3,4 +3,4 @@\n context\n-old line\n+new line\n context\n".to_string(),
+        modified_lines: vec![4],
+    };
+    let patch = super::build_hunk_patch("src/file.txt", &[hunk]);
+    assert!(patch.starts_with("--- a/src/file.txt\n+++ b/src/file.txt\n"));
+    assert!(patch.contains("@@ -3,4 +3,4 @@"));
+    assert!(patch.contains("-old line"));
+    assert!(patch.contains("+new line"));
+}
+
+#[test]
+fn build_hunk_patch_multiple_hunks() {
+    let hunk1 = super::DiffHunk {
+        text: "@@ -3,4 +3,4 @@\n context\n-old1\n+new1\n context\n".to_string(),
+        modified_lines: vec![4],
+    };
+    let hunk2 = super::DiffHunk {
+        text: "@@ -20,4 +20,4 @@\n context\n-old2\n+new2\n context\n".to_string(),
+        modified_lines: vec![21],
+    };
+    let patch = super::build_hunk_patch("src/file.txt", &[hunk1, hunk2]);
+    // Should have one file header and both hunks
+    assert_eq!(patch.matches("--- a/").count(), 1);
+    assert_eq!(patch.matches("@@ -").count(), 2);
+}
+
+#[test]
+fn parse_hunks_sql_comment_lines() {
+    let diff = "\
+--- a/query.sql
++++ b/query.sql
+@@ -1,3 +1,3 @@
+ SELECT *
+--- main query
++-- updated query
+ FROM users
+";
+    let hunks = super::parse_hunks(diff);
+    assert_eq!(hunks.len(), 1);
+    assert_eq!(
+        hunks[0].modified_lines,
+        vec![2],
+        "SQL comment line starting with '-- ' must be tracked as a modified line"
     );
 }
 
@@ -302,6 +371,180 @@ fn absorb_with_woven_branches() {
         );
 
         // Working tree should be clean (feature.txt absorbed)
+        test_repo.assert_working_tree_clean();
+    });
+}
+
+#[test]
+fn absorb_split_hunks_to_different_commits() {
+    let test_repo = TestRepo::new_with_remote();
+
+    // Create two commits with content in distant regions of the same file.
+    // Need enough gap (>6 lines) between regions so git diff produces separate hunks.
+    // Commit 1: lines 1-3 plus padding
+    test_repo.write_file(
+        "shared.txt",
+        "line1 from c1\nline2 from c1\nline3 from c1\n\
+         pad1\npad2\npad3\npad4\npad5\npad6\npad7\npad8\n",
+    );
+    test_repo.stage_files(&["shared.txt"]);
+    test_repo.commit_staged("Commit 1");
+
+    // Commit 2: appends lines far away from commit 1's region
+    test_repo.write_file(
+        "shared.txt",
+        "line1 from c1\nline2 from c1\nline3 from c1\n\
+         pad1\npad2\npad3\npad4\npad5\npad6\npad7\npad8\n\
+         line12 from c2\nline13 from c2\nline14 from c2\n",
+    );
+    test_repo.stage_files(&["shared.txt"]);
+    test_repo.commit_staged("Commit 2");
+
+    // Modify lines from both commits — separate hunks due to distance
+    test_repo.write_file(
+        "shared.txt",
+        "MODIFIED line1\nline2 from c1\nline3 from c1\n\
+         pad1\npad2\npad3\npad4\npad5\npad6\npad7\npad8\n\
+         MODIFIED line12\nline13 from c2\nline14 from c2\n",
+    );
+
+    test_repo.in_dir(|| {
+        let result = super::run(false, vec![]);
+        assert!(
+            result.is_ok(),
+            "hunk-level absorb should succeed: {:?}",
+            result
+        );
+
+        // Working tree should be clean — both hunks absorbed
+        test_repo.assert_working_tree_clean();
+
+        // Commit messages preserved
+        assert_eq!(test_repo.get_message(0), "Commit 2");
+        assert_eq!(test_repo.get_message(1), "Commit 1");
+    });
+}
+
+#[test]
+fn absorb_split_with_pure_addition_hunk() {
+    let test_repo = TestRepo::new_with_remote();
+
+    test_repo.write_file("file.txt", "line1\nline2\nline3\n");
+    test_repo.stage_files(&["file.txt"]);
+    test_repo.commit_staged("Add file");
+
+    // Modify line1 (absorbable) and append new lines (pure addition)
+    test_repo.write_file(
+        "file.txt",
+        "MODIFIED line1\nline2\nline3\nnew line4\nnew line5\n",
+    );
+
+    test_repo.in_dir(|| {
+        let result = super::run(false, vec![]);
+        assert!(
+            result.is_ok(),
+            "mixed split absorb should succeed: {:?}",
+            result
+        );
+
+        // The modified hunk should be absorbed, but pure addition stays in working tree
+        let content = test_repo.read_file("file.txt");
+        assert!(
+            content.contains("new line4"),
+            "pure addition hunk should remain in working tree"
+        );
+    });
+}
+
+#[test]
+fn absorb_skipped_patch_only_contains_skipped_files() {
+    let test_repo = TestRepo::new_with_remote();
+
+    // Create two commits with separate files
+    test_repo.write_file("absorbable.txt", "original content\n");
+    test_repo.stage_files(&["absorbable.txt"]);
+    test_repo.commit_staged("Add absorbable");
+
+    test_repo.write_file("skippable.txt", "line1\nline2\n");
+    test_repo.stage_files(&["skippable.txt"]);
+    test_repo.commit_staged("Add skippable");
+
+    // Modify absorbable.txt (will be absorbed into its commit)
+    test_repo.write_file("absorbable.txt", "modified content\n");
+
+    // Append pure-addition lines to skippable.txt (will be skipped)
+    test_repo.write_file("skippable.txt", "line1\nline2\nnew line3\n");
+
+    test_repo.in_dir(|| {
+        let result = super::run(
+            false,
+            vec!["absorbable.txt".to_string(), "skippable.txt".to_string()],
+        );
+        assert!(result.is_ok(), "absorb failed: {:?}", result);
+
+        // absorbable.txt should be clean (absorbed into its commit)
+        let abs_diff =
+            crate::git_commands::diff_head_file(&std::path::PathBuf::from("."), "absorbable.txt")
+                .unwrap();
+        assert!(
+            abs_diff.is_empty(),
+            "absorbable.txt should be clean after absorb, but has diff:\n{}",
+            abs_diff
+        );
+
+        // skippable.txt should still have the pure-addition leftover
+        let content = test_repo.read_file("skippable.txt");
+        assert!(
+            content.contains("new line3"),
+            "skippable.txt should retain its skipped changes"
+        );
+    });
+}
+
+#[test]
+fn absorb_file_with_sql_comment_lines() {
+    let test_repo = TestRepo::new_with_remote();
+    // Create a SQL file with comment lines
+    test_repo.write_file("query.sql", "SELECT *\n-- main query\nFROM users\n");
+    test_repo.stage_files(&["query.sql"]);
+    test_repo.commit_staged("Add SQL query");
+
+    // Modify the comment line
+    test_repo.write_file("query.sql", "SELECT *\n-- updated query\nFROM users\n");
+
+    test_repo.in_dir(|| {
+        let result = super::run(false, vec![]);
+        assert!(
+            result.is_ok(),
+            "absorb should handle -- lines: {:?}",
+            result.err()
+        );
+        test_repo.assert_working_tree_clean();
+        // Verify the change was absorbed
+        let content = test_repo.read_file("query.sql");
+        assert!(
+            content.contains("-- updated query"),
+            "absorbed content should contain the updated SQL comment"
+        );
+    });
+}
+
+#[test]
+fn absorb_staged_only_changes() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit("Add file", "target.txt");
+
+    // Stage a change without leaving unstaged modifications
+    test_repo.write_file("target.txt", "staged content\n");
+    test_repo.stage_files(&["target.txt"]);
+
+    test_repo.in_dir(|| {
+        let result = super::run(false, vec![]);
+        assert!(
+            result.is_ok(),
+            "absorb should handle staged-only changes: {:?}",
+            result.err()
+        );
         test_repo.assert_working_tree_clean();
     });
 }

--- a/src/git_commands/mod.rs
+++ b/src/git_commands/mod.rs
@@ -125,21 +125,26 @@ pub fn diff_commit_file(workdir: &Path, oid: &str, path: &str) -> Result<String>
 ///
 /// Wraps `git apply` with the patch passed via stdin.
 pub fn apply_patch(workdir: &Path, patch: &str) -> Result<()> {
-    apply_patch_impl(workdir, patch, false)
+    apply_patch_with_flags(workdir, patch, &[])
 }
 
 /// Apply a patch in reverse from stdin.
 ///
 /// Wraps `git apply --reverse` with the patch passed via stdin.
 pub fn apply_patch_reverse(workdir: &Path, patch: &str) -> Result<()> {
-    apply_patch_impl(workdir, patch, true)
+    apply_patch_with_flags(workdir, patch, &["--reverse"])
 }
 
-fn apply_patch_impl(workdir: &Path, patch: &str, reverse: bool) -> Result<()> {
+/// Apply a patch to the index only (not the working tree).
+///
+/// Wraps `git apply --cached` with the patch passed via stdin.
+pub fn apply_cached_patch(workdir: &Path, patch: &str) -> Result<()> {
+    apply_patch_with_flags(workdir, patch, &["--cached"])
+}
+
+fn apply_patch_with_flags(workdir: &Path, patch: &str, flags: &[&str]) -> Result<()> {
     let mut args = vec!["apply"];
-    if reverse {
-        args.push("--reverse");
-    }
+    args.extend(flags);
 
     let start = Instant::now();
     let mut child = Command::new("git")
@@ -167,8 +172,8 @@ fn apply_patch_impl(workdir: &Path, patch: &str, reverse: bool) -> Result<()> {
     );
 
     if !output.status.success() {
-        let flag = if reverse { " --reverse" } else { "" };
-        bail!("Git apply{} failed", flag);
+        let flag = args[1..].join(" ");
+        bail!("Git apply {} failed", flag);
     }
 
     Ok(())


### PR DESCRIPTION
Previously, absorb worked at the file level: if all modified lines in a
file traced to one commit, the whole file was absorbed; if lines traced
to different commits, the entire file was skipped.

Now absorb works at the hunk level. The unified diff is split into
individual hunks, each hunk is independently blamed, and assigned to its
originating commit. When a file has hunks targeting different commits,
each hunk is absorbed separately via `git apply --cached`. Hunks that
cannot be attributed (pure additions, out of scope, ambiguous within a
single hunk) are left in the working tree.

Closes #48

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>