### PR TITLE
feat: add centralized resolve_arg() and migrate all callers

### DIFF
--- a/specs/001-status.md
+++ b/specs/001-status.md
@@ -271,6 +271,12 @@ Unknown identifiers are silently ignored.
 - **No merge commit handling**: merge commits are displayed like regular
   commits. There is no special visual treatment for merges.
 
+### CWD-relative file paths
+
+File paths in the status output are displayed relative to the current
+working directory, matching `git status` behavior. When run from
+`<repo>/src/`, the file `src/main.rs` is shown as `main.rs`.
+
 ## Branch Topology
 
 Feature branches are expected to be stacked linearly on top of each other.

--- a/specs/002-shortid.md
+++ b/specs/002-shortid.md
@@ -269,6 +269,21 @@ The resolution system ensures that **what you see is what you type**:
 
 Git reference resolution has no prerequisites (works in any repository).
 
+### Argument resolution: `resolve_arg()`
+
+All commands resolve user-provided arguments through `git::resolve_arg(repo, arg, accept)`.
+The `accept` parameter is a `&[TargetKind]` slice specifying which kinds of targets the
+command accepts and in what priority order. Resolution strategies are only attempted for
+the listed kinds. Merge commits are automatically rejected when resolving `Commit` targets.
+CWD-relative path conversion is handled internally for `File` targets.
+
+Available `TargetKind` values:
+- `File` — a working-tree file path (CWD-relative → repo-relative conversion applied)
+- `Branch` — a local branch name
+- `Commit` — a non-merge commit (hash, `HEAD`, etc.; branch names are excluded)
+- `CommitFile` — a commit-file reference (e.g. `02:0`)
+- `Unstaged` — the unstaged working directory (`zz`)
+
 ## Design Decisions
 
 - **Global collision resolution:** all entity types share one ID namespace.

--- a/specs/006-commit.md
+++ b/specs/006-commit.md
@@ -122,6 +122,8 @@ conflicts with standard git tools.
 The `-b <branch>` argument uses the shared resolution strategy (see Spec 002),
 restricted to branches only:
 
+Arguments are resolved via `resolve_arg()` with `accept = [Branch]` — see spec 002 for the resolution algorithm.
+
 **Resolution Order:**
 
 1. **Local branch names** - Exact match for woven feature branches

--- a/specs/007-fold.md
+++ b/specs/007-fold.md
@@ -284,6 +284,8 @@ rebase operation. The source uses the `commit_sid:index` format.
 
 ## Target Resolution
 
+Arguments are resolved via `resolve_arg()` with `accept = [Commit, CommitFile, File, Unstaged]` — see spec 002 for the resolution algorithm.
+
 Arguments are resolved using the shared resolution strategy (see Spec 002)
 with an additional filesystem fallback:
 

--- a/specs/008-drop.md
+++ b/specs/008-drop.md
@@ -190,6 +190,8 @@ Prompt: `"Discard all local changes?"`. Success: `"Discarded all local changes"`
 
 ## Target Resolution
 
+Arguments are resolved via `resolve_arg()` with `accept = [File, Branch, Commit, Unstaged]` — see spec 002 for the resolution algorithm.
+
 The `<target>` is interpreted using the shared resolution strategy
 (see Spec 002):
 

--- a/specs/011-push.md
+++ b/specs/011-push.md
@@ -154,7 +154,7 @@ Merge commits in the branch are skipped when gathering commit messages.
 
 ## Branch Selection
 
-- **Explicit argument**: Resolved via `resolve_target()`, must be a woven branch
+- **Explicit argument**: Resolved via `resolve_arg()` with `accept = [Branch]` — see spec 002. Must be a woven branch.
 - **Interactive picker**: Lists woven branches from `info.branches` via `cliclack::select`
 - No "create new" option (unlike commit — we're pushing existing branches)
 

--- a/specs/012-absorb.md
+++ b/specs/012-absorb.md
@@ -176,6 +176,8 @@ shown in parentheses.
 - At least one commit in scope (between merge-base and HEAD)
 - At least one tracked file with uncommitted changes
 
+File arguments are resolved via `resolve_arg()` with `accept = [File]` — see spec 002 for the resolution algorithm.
+
 ## Error Cases
 
 - **No changes**: `"Nothing to absorb — make some changes to tracked files first"`

--- a/src/absorb.rs
+++ b/src/absorb.rs
@@ -326,38 +326,18 @@ fn get_changed_files(
     } else {
         let mut result = Vec::new();
         for arg in user_files {
-            let path = resolve_file_arg(repo, workdir, arg)?;
+            let path = resolve_file_arg(repo, arg)?;
             result.push(path);
         }
         Ok(result)
     }
 }
 
-/// Resolve a user argument to a file path.
-///
-/// Tries, in order:
-/// 1. Literal file path (exists on disk or has a diff against HEAD)
-/// 2. Short ID via `resolve_target` → `Target::File(path)`
-fn resolve_file_arg(repo: &Repository, workdir: &Path, arg: &str) -> Result<String> {
-    // Try as literal path first
-    let full_path = workdir.join(arg);
-    if full_path.exists() {
-        return Ok(arg.to_string());
-    }
-    // Check if it's a deletion (file existed in HEAD but was deleted)
-    let diff = git_commands::diff_head_file(workdir, arg)?;
-    if !diff.is_empty() {
-        return Ok(arg.to_string());
-    }
-
-    // Try as short ID
-    match git::resolve_target(repo, arg)? {
+/// Resolve a user argument to a file path using the centralized resolver.
+fn resolve_file_arg(repo: &Repository, arg: &str) -> Result<String> {
+    match git::resolve_arg(repo, arg, &[git::TargetKind::File])? {
         git::Target::File(path) => Ok(path),
-        _ => bail!(
-            "'{}' is not a file path or file short ID\n\
-             Run `git-loom status` to see available IDs",
-            arg
-        ),
+        _ => unreachable!(),
     }
 }
 

--- a/src/branch/new.rs
+++ b/src/branch/new.rs
@@ -94,7 +94,8 @@ fn resolve_commit(
             Ok(info.upstream.merge_base_oid.to_string())
         }
         Some(t) => {
-            let resolved = git::resolve_target(repo, t)?;
+            let resolved =
+                git::resolve_arg(repo, t, &[git::TargetKind::Commit, git::TargetKind::Branch])?;
             match resolved {
                 git::Target::Commit(hash) => Ok(hash),
                 git::Target::Branch(name) => {
@@ -106,14 +107,7 @@ fn resolve_commit(
                         .context("Branch does not point to a commit")?;
                     Ok(oid.to_string())
                 }
-                git::Target::File(path) => bail!(
-                    "Target resolved to file '{}'\nUse a commit or branch target instead",
-                    path
-                ),
-                git::Target::Unstaged => bail!("Cannot use unstaged as a branch target"),
-                git::Target::CommitFile { .. } => {
-                    bail!("Cannot use a commit file as a branch target")
-                }
+                _ => unreachable!(),
             }
         }
     }

--- a/src/branch/unmerge.rs
+++ b/src/branch/unmerge.rs
@@ -61,7 +61,7 @@ fn resolve_woven_branch(
     info: &git::RepoInfo,
     branch_arg: &str,
 ) -> Result<String> {
-    let name = git::resolve_target(repo, branch_arg)?.expect_branch()?;
+    let name = git::resolve_arg(repo, branch_arg, &[git::TargetKind::Branch])?.expect_branch()?;
     if info.branches.iter().any(|b| b.name == name) {
         Ok(name)
     } else {

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -130,7 +130,7 @@ fn resolve_staging(repo: &Repository, workdir: &std::path::Path, files: &[String
 
     let mut resolved_paths = Vec::new();
     for arg in files {
-        let path = resolve_file_arg(repo, workdir, arg)?;
+        let path = resolve_file_arg(repo, arg)?;
         resolved_paths.push(path);
     }
 
@@ -140,19 +140,11 @@ fn resolve_staging(repo: &Repository, workdir: &std::path::Path, files: &[String
     Ok(())
 }
 
-/// Resolve a file argument: try as short ID first, fall back to filesystem path.
-fn resolve_file_arg(repo: &Repository, workdir: &std::path::Path, arg: &str) -> Result<String> {
-    match git::resolve_target(repo, arg) {
-        Ok(Target::File(path)) => Ok(path),
-        Ok(_) => bail!("Target '{}' is not a file", arg),
-        Err(_) => {
-            let full_path = workdir.join(arg);
-            if full_path.exists() {
-                Ok(arg.to_string())
-            } else {
-                bail!("File '{}' not found", arg)
-            }
-        }
+/// Resolve a file argument using the centralized resolver.
+fn resolve_file_arg(repo: &Repository, arg: &str) -> Result<String> {
+    match git::resolve_arg(repo, arg, &[git::TargetKind::File])? {
+        Target::File(path) => Ok(path),
+        _ => unreachable!(),
     }
 }
 
@@ -203,7 +195,7 @@ fn resolve_explicit_branch(
     workdir: &std::path::Path,
     branch: &str,
 ) -> Result<String> {
-    match git::resolve_target(repo, branch) {
+    match git::resolve_arg(repo, branch, &[git::TargetKind::Branch]) {
         Ok(target) => {
             let name = target.expect_branch()?;
             if info.branches.iter().any(|b| b.name == name) {

--- a/src/commit_test.rs
+++ b/src/commit_test.rs
@@ -560,7 +560,11 @@ fn commit_nonexistent_file_fails() {
     });
 
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("not found"));
+    // With the centralized resolver, a nonexistent file produces a "did not resolve to a file" error
+    assert!(
+        result.unwrap_err().to_string().contains("file"),
+        "Error should mention file"
+    );
 }
 
 #[test]

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use git2::Repository;
 
 use crate::branch::is_on_first_parent_line;
-use crate::git::{self, Target};
+use crate::git::{self, Target, TargetKind};
 use crate::git_commands::{self, git_branch};
 use crate::msg;
 use crate::weave::{self, Weave};
@@ -19,16 +19,23 @@ use crate::weave::{self, Weave};
 pub fn run(target: String, skip_confirm: bool) -> Result<()> {
     let repo = git::open_repo()?;
 
-    let resolved = git::resolve_target(&repo, &target)?;
+    let resolved = git::resolve_arg(
+        &repo,
+        &target,
+        &[
+            TargetKind::File,
+            TargetKind::Branch,
+            TargetKind::Commit,
+            TargetKind::Unstaged,
+        ],
+    )?;
 
     match resolved {
         Target::Commit(hash) => drop_commit(&repo, &hash, skip_confirm),
         Target::Branch(name) => drop_branch(&repo, &name, skip_confirm),
         Target::File(path) => drop_file(&repo, &path, skip_confirm),
         Target::Unstaged => drop_all(&repo, skip_confirm),
-        Target::CommitFile { .. } => {
-            bail!("Cannot drop a commit file\nUse `git loom fold <file_id> zz` to uncommit a file")
-        }
+        _ => unreachable!(),
     }
 }
 

--- a/src/drop_test.rs
+++ b/src/drop_test.rs
@@ -618,3 +618,53 @@ fn drop_all_fails_when_no_changes() {
         "error should mention no changes"
     );
 }
+
+// ── Integration tests for centralized resolver ───────────────────────────
+
+#[test]
+fn drop_merge_commit_fails() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit("a.txt", "a.txt");
+    let a_oid = test_repo.head_oid();
+    let upstream_oid = test_repo.find_remote_branch_target("origin/main");
+
+    // Create a merge commit
+    test_repo.commit_merge("Merge side", a_oid, upstream_oid);
+    let merge_oid = test_repo.head_oid();
+
+    let result = test_repo.in_dir(|| crate::drop::run(merge_oid.to_string(), true));
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("merge commit"),
+        "Error should mention merge commit"
+    );
+}
+
+#[test]
+fn drop_prefers_file_over_branch_name_collision() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    let a1_oid = test_repo.head_oid();
+    test_repo.create_branch_at_commit("collision", a1_oid);
+    test_repo.write_file("collision", "dirty data");
+
+    let result = test_repo.in_dir(|| crate::drop::run("collision".to_string(), true));
+    assert!(result.is_ok(), "Expected ok, got: {:?}", result);
+    // Branch should still exist (file was dropped, not the branch)
+    assert!(test_repo.branch_exists("collision"));
+}
+
+#[test]
+fn drop_file_resolves_from_nested_cwd() {
+    let test_repo = TestRepo::new_with_remote();
+    let sub_dir = test_repo.workdir().join("sub");
+    std::fs::create_dir_all(&sub_dir).unwrap();
+    std::fs::write(sub_dir.join("file.txt"), "content").unwrap();
+    test_repo.stage_files(&["sub/file.txt"]);
+    test_repo.commit_staged("add sub/file.txt");
+    // Dirty the file
+    std::fs::write(sub_dir.join("file.txt"), "modified").unwrap();
+
+    let result = test_repo.in_dir_path(&sub_dir, || crate::drop::run("file.txt".to_string(), true));
+    assert!(result.is_ok(), "Expected ok, got: {:?}", result);
+}

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, bail};
 use git2::{Repository, StatusOptions};
 
 use crate::commit;
-use crate::git::{self, Target};
+use crate::git::{self, Target, TargetKind};
 use crate::git_commands::{self, git_branch, git_commit, git_rebase};
 use crate::msg;
 use crate::weave::{self, Weave};
@@ -56,9 +56,29 @@ pub fn run(create: bool, args: Vec<String>) -> Result<()> {
     // Resolve all arguments
     let resolved_sources: Vec<Target> = source_args
         .iter()
-        .map(|s| resolve_fold_arg(&repo, s))
+        .map(|s| {
+            git::resolve_arg(
+                &repo,
+                s,
+                &[
+                    TargetKind::Commit,
+                    TargetKind::CommitFile,
+                    TargetKind::File,
+                    TargetKind::Unstaged,
+                ],
+            )
+        })
         .collect::<Result<Vec<_>, _>>()?;
-    let resolved_target = resolve_fold_arg(&repo, target_arg)?;
+    let resolved_target = git::resolve_arg(
+        &repo,
+        target_arg,
+        &[
+            TargetKind::Commit,
+            TargetKind::CommitFile,
+            TargetKind::File,
+            TargetKind::Unstaged,
+        ],
+    )?;
 
     // Classify and dispatch
     match classify(&resolved_sources, &resolved_target)? {
@@ -96,12 +116,10 @@ fn run_create(repo: &Repository, args: &[String]) -> Result<()> {
     let workdir = git::require_workdir(repo, "fold")?;
 
     // Resolve source — must be a commit
-    let source = resolve_fold_arg(repo, source_arg)?;
+    let source = git::resolve_arg(repo, source_arg, &[TargetKind::Commit])?;
     let commit_hash = match source {
         Target::Commit(hash) => hash,
-        Target::Branch(_) => bail!("Source must be a commit, not a branch"),
-        Target::File(_) => bail!("Source must be a commit, not a file"),
-        _ => bail!("Source must be a commit"),
+        _ => unreachable!(),
     };
 
     git_branch::validate_name(branch_name)?;
@@ -163,10 +181,10 @@ fn create_branch_and_move(
 /// Single-argument form: `loom fold <target>`. The target must resolve to a
 /// commit. If nothing is staged, bails with the same message as `loom commit`.
 fn run_staged(repo: &Repository, target_arg: &str) -> Result<()> {
-    let resolved = resolve_fold_arg(repo, target_arg)?;
+    let resolved = git::resolve_arg(repo, target_arg, &[TargetKind::Commit])?;
     let commit_hash = match resolved {
         Target::Commit(hash) => hash,
-        _ => bail!("Target must be a commit when folding staged files"),
+        _ => unreachable!(),
     };
 
     commit::verify_has_staged_changes(repo)?;
@@ -344,14 +362,6 @@ fn collect_changed_files(repo: &Repository) -> Result<Vec<String>> {
         }
     }
     Ok(paths)
-}
-
-/// Resolve an argument for the fold command.
-///
-/// Delegates to `resolve_target()` which handles branches, git refs, short IDs,
-/// filenames, and filesystem paths with changes.
-fn resolve_fold_arg(repo: &Repository, arg: &str) -> Result<Target> {
-    git::resolve_target(repo, arg)
 }
 
 /// Fold file changes into a commit (Case 1: File(s) + Commit).

--- a/src/fold_test.rs
+++ b/src/fold_test.rs
@@ -1289,37 +1289,48 @@ fn resolve_fold_arg_filesystem_path() {
     // Modify a file — should resolve as Target::File via filesystem fallback
     test_repo.write_file("file1.txt", "changed");
 
-    let result = super::resolve_fold_arg(&test_repo.repo, "file1.txt");
+    let result = test_repo
+        .in_dir(|| git::resolve_arg(&test_repo.repo, "file1.txt", &[git::TargetKind::File]));
     assert!(result.is_ok(), "resolve failed: {:?}", result);
     assert!(matches!(result.unwrap(), git::Target::File(_)));
 }
 
 #[test]
 fn resolve_fold_arg_commit_hash() {
-    let test_repo = TestRepo::new();
-    let c1_oid = test_repo.commit("commit", "file1.txt");
+    let test_repo = TestRepo::new_with_remote();
+    let c1_oid = test_repo.commit_empty("commit");
 
-    let result = super::resolve_fold_arg(&test_repo.repo, &c1_oid.to_string());
+    let result = test_repo.in_dir(|| {
+        git::resolve_arg(
+            &test_repo.repo,
+            &c1_oid.to_string(),
+            &[git::TargetKind::Commit],
+        )
+    });
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), git::Target::Commit(_)));
 }
 
 #[test]
 fn resolve_fold_arg_branch_name() {
-    let test_repo = TestRepo::new();
-    test_repo.create_branch("feature-a");
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    let a1_oid = test_repo.head_oid();
+    test_repo.create_branch_at_commit("feature-a", a1_oid);
 
-    let result = super::resolve_fold_arg(&test_repo.repo, "feature-a");
+    let result = test_repo
+        .in_dir(|| git::resolve_arg(&test_repo.repo, "feature-a", &[git::TargetKind::Branch]));
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), git::Target::Branch(_)));
 }
 
 #[test]
 fn resolve_fold_arg_head() {
-    let test_repo = TestRepo::new();
-    test_repo.commit("commit", "file1.txt");
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("commit");
 
-    let result = super::resolve_fold_arg(&test_repo.repo, "HEAD");
+    let result =
+        test_repo.in_dir(|| git::resolve_arg(&test_repo.repo, "HEAD", &[git::TargetKind::Commit]));
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), git::Target::Commit(_)));
 }
@@ -1398,9 +1409,10 @@ fn fold_create_rejects_non_commit_source() {
         &["feature-a".to_string(), "new-branch".to_string()],
     );
     assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
     assert!(
-        result.unwrap_err().to_string().contains("must be a commit"),
-        "should error when source is a branch"
+        err.contains("commit"),
+        "should error when source is a branch, got: {err}"
     );
 }
 
@@ -1469,19 +1481,20 @@ fn fold_staged_only_uses_staged_not_unstaged() {
 
 #[test]
 fn fold_staged_non_commit_target_fails() {
-    let test_repo = TestRepo::new();
+    let test_repo = TestRepo::new_with_remote();
     test_repo.commit("First commit", "file1.txt");
+    let a1_oid = test_repo.head_oid();
+    test_repo.create_branch_at_commit("feature-a", a1_oid);
 
     test_repo.write_file("file1.txt", "staged content");
     test_repo.stage_files(&["file1.txt"]);
 
-    // The default branch resolves as a Branch, not a commit
-    let branch_name = test_repo.current_branch_name();
-    let result = super::run_staged(&test_repo.repo, &branch_name);
+    // Passing a branch name when only Commit is accepted should fail
+    let result = test_repo.in_dir(|| super::run_staged(&test_repo.repo, "feature-a"));
     assert!(result.is_err(), "should have failed");
     let err_msg = result.unwrap_err().to_string();
     assert!(
-        err_msg.contains("must be a commit"),
+        err_msg.contains("commit"),
         "should error when target is not a commit, got: {err_msg}"
     );
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -154,6 +154,241 @@ impl Target {
     }
 }
 
+/// Which kinds of targets `resolve_arg` should try matching.
+/// The order in the `accept` slice determines priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetKind {
+    File,
+    Branch,
+    Commit,
+    CommitFile,
+    Unstaged,
+}
+
+impl std::fmt::Display for TargetKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TargetKind::File => write!(f, "file"),
+            TargetKind::Branch => write!(f, "branch"),
+            TargetKind::Commit => write!(f, "commit"),
+            TargetKind::CommitFile => write!(f, "commit file"),
+            TargetKind::Unstaged => write!(f, "unstaged changes"),
+        }
+    }
+}
+
+/// Resolve a user-provided argument to a `Target`.
+///
+/// Only the resolution strategies for the kinds listed in `accept` are
+/// attempted, in the order given.  The first match wins.  If nothing
+/// matches, a generic error lists the accepted types.
+pub fn resolve_arg(repo: &Repository, arg: &str, accept: &[TargetKind]) -> Result<Target> {
+    // Phase 1: direct checks (cheap, no graph building)
+    for kind in accept {
+        let result = match kind {
+            TargetKind::File => try_resolve_file(repo, arg)?,
+            TargetKind::Branch => try_resolve_branch(repo, arg)?,
+            TargetKind::Commit => try_resolve_commit(repo, arg)?,
+            TargetKind::CommitFile | TargetKind::Unstaged => None,
+        };
+        if let Some(target) = result {
+            return Ok(target);
+        }
+    }
+
+    // Phase 2: shortid resolution (expensive, builds the graph)
+    if let Some(target) = try_resolve_shortid(repo, arg, accept)? {
+        return Ok(target);
+    }
+
+    let types: Vec<_> = accept.iter().map(|k| k.to_string()).collect();
+    bail!("'{}' did not resolve to a {}", arg, types.join(" or "))
+}
+
+/// Reject a commit if it is a merge commit.
+fn reject_merge_commit(repo: &Repository, oid: git2::Oid) -> Result<()> {
+    let commit = repo.find_commit(oid)?;
+    if commit.parent_count() > 1 {
+        bail!("Cannot operate on a merge commit");
+    }
+    Ok(())
+}
+
+/// Try to resolve `arg` as a file path (CWD-relative → repo-relative).
+fn try_resolve_file(repo: &Repository, arg: &str) -> Result<Option<Target>> {
+    let repo_path = cwd_to_repo_path(repo, arg).unwrap_or_else(|_| arg.to_string());
+    let workdir = match repo.workdir() {
+        Some(w) => w,
+        None => return Ok(None),
+    };
+    let full_path = workdir.join(&repo_path);
+    if full_path.exists() {
+        return Ok(Some(Target::File(repo_path)));
+    }
+    // Check for deleted files (removed from disk but changed vs HEAD)
+    let diff = crate::git_commands::diff_head_file(workdir, &repo_path)?;
+    if !diff.is_empty() {
+        return Ok(Some(Target::File(repo_path)));
+    }
+    Ok(None)
+}
+
+/// Try to resolve `arg` as a local branch name.
+fn try_resolve_branch(repo: &Repository, arg: &str) -> Result<Option<Target>> {
+    if let Ok(branch) = repo.find_branch(arg, BranchType::Local) {
+        let name = branch
+            .name()?
+            .context("Branch name is not valid UTF-8")?
+            .to_string();
+        return Ok(Some(Target::Branch(name)));
+    }
+    Ok(None)
+}
+
+/// Try to resolve `arg` as a git reference (hash, HEAD, tag, etc.).
+/// Rejects merge commits. Does NOT resolve local branch names as commits —
+/// use `try_resolve_branch` for that.
+fn try_resolve_commit(repo: &Repository, arg: &str) -> Result<Option<Target>> {
+    // Explicitly exclude local branch names so that branch and commit targets
+    // remain distinct when the caller specifies only TargetKind::Commit.
+    if repo.find_branch(arg, BranchType::Local).is_ok() {
+        return Ok(None);
+    }
+    if let Ok(obj) = repo.revparse_single(arg)
+        && let Ok(commit) = obj.peel_to_commit()
+    {
+        let oid = commit.id();
+        reject_merge_commit(repo, oid)?;
+        return Ok(Some(Target::Commit(oid.to_string())));
+    }
+    Ok(None)
+}
+
+/// Try to resolve `arg` via the shortid allocator, but only return
+/// results matching one of the `accept` kinds.
+fn try_resolve_shortid(
+    repo: &Repository,
+    arg: &str,
+    accept: &[TargetKind],
+) -> Result<Option<Target>> {
+    let needs_files = arg.contains(':');
+    let info = gather_repo_info(repo, needs_files, 1)?;
+    let entities = info.collect_entities();
+    let allocator = crate::shortid::IdAllocator::new(entities);
+
+    for kind in accept {
+        match kind {
+            TargetKind::Unstaged => {
+                if allocator.get_unstaged() == arg {
+                    return Ok(Some(Target::Unstaged));
+                }
+            }
+            TargetKind::Branch => {
+                for branch in &info.branches {
+                    if allocator.get_branch(&branch.name) == arg {
+                        return Ok(Some(Target::Branch(branch.name.clone())));
+                    }
+                }
+            }
+            TargetKind::Commit => {
+                for commit in &info.commits {
+                    if allocator.get_commit(commit.oid) == arg {
+                        reject_merge_commit(repo, commit.oid)?;
+                        return Ok(Some(Target::Commit(commit.oid.to_string())));
+                    }
+                }
+            }
+            TargetKind::File => {
+                for file in &info.working_changes {
+                    if allocator.get_file(&file.path) == arg || file.path == arg {
+                        return Ok(Some(Target::File(file.path.clone())));
+                    }
+                }
+            }
+            TargetKind::CommitFile => {
+                if let Some((commit_part, index_part)) = arg.split_once(':')
+                    && let Ok(index) = index_part.parse::<usize>()
+                {
+                    for commit in &info.commits {
+                        if allocator.get_commit(commit.oid) == commit_part {
+                            if let Some(file) = commit.files.get(index) {
+                                return Ok(Some(Target::CommitFile {
+                                    commit: commit.oid.to_string(),
+                                    path: file.path.clone(),
+                                }));
+                            }
+                            bail!(
+                                "Commit has no file at index {}\nRun `git-loom status -f` to see available IDs",
+                                index
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Convert a CWD-relative path to a repo-relative path.
+///
+/// If CWD is `<repo>/src/` and `arg` is `"git.rs"`, returns `"src/git.rs"`.
+fn cwd_to_repo_path(repo: &Repository, arg: &str) -> Result<String> {
+    let prefix = cwd_relative_to_repo(repo)?;
+    if prefix.is_empty() {
+        return Ok(arg.to_string());
+    }
+    Ok(format!("{}/{}", prefix, arg))
+}
+
+/// Compute the CWD relative to the repo root as a forward-slash string.
+///
+/// Returns an empty string when CWD is the repo root.
+pub fn cwd_relative_to_repo(repo: &Repository) -> Result<String> {
+    let workdir = repo
+        .workdir()
+        .context("Repository has no working directory")?;
+    let cwd = std::env::current_dir()?;
+    // Canonicalize both paths to normalize platform-specific representations
+    // (e.g., drive letter case and path separator style on Windows).
+    let workdir_canonical =
+        std::fs::canonicalize(workdir).unwrap_or_else(|_| workdir.to_path_buf());
+    let cwd_canonical = std::fs::canonicalize(&cwd).unwrap_or(cwd);
+    let rel = cwd_canonical
+        .strip_prefix(&workdir_canonical)
+        .unwrap_or(std::path::Path::new(""));
+    let s = rel
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    Ok(s)
+}
+
+/// Convert a repo-relative path to a CWD-relative display string given
+/// a pre-computed CWD prefix (as returned by [`cwd_relative_to_repo`]).
+///
+/// - Empty prefix → path returned unchanged (CWD is repo root).
+/// - Path starts with prefix → strip it (file is under CWD).
+/// - Otherwise → prepend the appropriate number of `../` components.
+pub fn cwd_relative_path(repo_path: &str, cwd_prefix: &str) -> String {
+    if cwd_prefix.is_empty() {
+        return repo_path.to_string();
+    }
+    let cwd_parts: Vec<&str> = cwd_prefix.split('/').collect();
+    let file_parts: Vec<&str> = repo_path.split('/').collect();
+    let common = cwd_parts
+        .iter()
+        .zip(file_parts.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let ups = cwd_parts.len() - common;
+    let remaining = &file_parts[common..];
+    let mut result: Vec<&str> = vec![".."; ups];
+    result.extend_from_slice(remaining);
+    result.join("/")
+}
+
 /// Info about the upstream tracking branch and the merge-base with HEAD.
 #[derive(Debug)]
 pub struct UpstreamInfo {
@@ -350,73 +585,6 @@ pub fn gather_repo_info(repo: &Repository, show_files: bool, context: usize) -> 
     })
 }
 
-/// Resolve a target identifier to a commit, branch, or file.
-///
-/// This function tries multiple resolution strategies in order:
-///
-/// # Resolution Strategy
-///
-/// 1. **Local branch names** - Exact match for local branch names
-///    - Branch names resolve to `Target::Branch(name)`
-///    - Example: "feature-a" → Target::Branch("feature-a")
-/// 2. **Git references** - Any valid git reference (hash, HEAD, etc.)
-///    - All other references resolve to `Target::Commit(hash)`
-///    - Example: "abc123" → Target::Commit(full_hash)
-/// 3. **ShortIDs** - Searches branches, commits, files in order
-///    - Branch shortids resolve to `Target::Branch(name)`
-///    - Commit shortids resolve to `Target::Commit(hash)`
-///    - File shortids resolve to `Target::File(path)`
-///
-/// This prioritization ensures branch names are always treated as branches,
-/// allowing intuitive operations like "git-loom reword feature-a -m new-name".
-/// To reference the commit at a branch tip, use its hash or commit shortid.
-///
-/// # Arguments
-///
-/// * `repo` - The git repository
-/// * `target` - The target identifier (branch name, git hash, shortid, etc.)
-///
-/// # Returns
-///
-/// Returns a `Target` enum indicating what the identifier resolved to:
-/// - `Target::Branch(name)` - A branch name (from full name or branch shortid)
-/// - `Target::Commit(hash)` - A commit hash (from git ref or commit shortid)
-/// - `Target::File(path)` - A file path (from file shortid only)
-pub fn resolve_target(repo: &Repository, target: &str) -> Result<Target> {
-    // First, check if it's a local branch name
-    // This allows intuitive branch operations: "git-loom reword feature-a -m new-name"
-    if let Ok(branch) = repo.find_branch(target, BranchType::Local) {
-        let branch_name = branch
-            .name()?
-            .context("Branch name is not valid UTF-8")?
-            .to_string();
-        return Ok(Target::Branch(branch_name));
-    }
-
-    // Try parsing as git reference (commit hash, HEAD, tag, etc.)
-    if let Ok(obj) = repo.revparse_single(target)
-        && let Ok(commit) = obj.peel_to_commit()
-    {
-        return Ok(Target::Commit(commit.id().to_string()));
-    }
-
-    // Not a valid git reference - try as shortid
-    // This requires building the full graph (needs upstream)
-    match resolve_shortid(repo, target) {
-        Ok(resolved) => Ok(resolved),
-        Err(shortid_err) => {
-            // Fall back to filesystem path with changes (file or directory)
-            if let Some(workdir) = repo.workdir() {
-                let full_path = workdir.join(target);
-                if full_path.exists() && path_has_changes(repo, target)? {
-                    return Ok(Target::File(target.to_string()));
-                }
-            }
-            Err(shortid_err)
-        }
-    }
-}
-
 /// Check if a path (file or directory) has staged or unstaged changes.
 pub fn path_has_changes(repo: &Repository, path: &str) -> Result<bool> {
     let mut opts = StatusOptions::new();
@@ -447,68 +615,6 @@ pub fn get_staged_files(repo: &Repository) -> Result<Vec<String>> {
         }
     }
     Ok(paths)
-}
-
-/// Resolve a shortid to a commit, branch, or file by rebuilding the graph.
-fn resolve_shortid(repo: &Repository, shortid: &str) -> Result<Target> {
-    // Only gather file info when the shortid looks like a commit-file reference (contains ':')
-    let needs_files = shortid.contains(':');
-    let info = gather_repo_info(repo, needs_files, 1)?;
-
-    // Build entities using the shared method
-    let entities = info.collect_entities();
-    let allocator = crate::shortid::IdAllocator::new(entities);
-
-    // Check if it matches the unstaged entity
-    if allocator.get_unstaged() == shortid {
-        return Ok(Target::Unstaged);
-    }
-
-    // Search for matching shortid in branches
-    for branch in &info.branches {
-        if allocator.get_branch(&branch.name) == shortid {
-            return Ok(Target::Branch(branch.name.clone()));
-        }
-    }
-
-    // Search for matching shortid in commits
-    for commit in &info.commits {
-        if allocator.get_commit(commit.oid) == shortid {
-            return Ok(Target::Commit(commit.oid.to_string()));
-        }
-    }
-
-    // Search for matching shortid or filename in working change files
-    for file in &info.working_changes {
-        if allocator.get_file(&file.path) == shortid || file.path == shortid {
-            return Ok(Target::File(file.path.clone()));
-        }
-    }
-
-    // Search for commit file shortids (format: "commit_sid:index")
-    if let Some((commit_part, index_part)) = shortid.split_once(':')
-        && let Ok(index) = index_part.parse::<usize>()
-    {
-        for commit in &info.commits {
-            if allocator.get_commit(commit.oid) == commit_part {
-                if let Some(file) = commit.files.get(index) {
-                    return Ok(Target::CommitFile {
-                        commit: commit.oid.to_string(),
-                        path: file.path.clone(),
-                    });
-                }
-                bail!(
-                    "Commit has no file at index {}\nRun `git-loom status -f` to see available IDs",
-                    index
-                );
-            }
-        }
-    }
-
-    bail!(
-        "No commit, branch, file, or target with shortid '{}'\nRun `git-loom status` to see available IDs",
-        shortid
-    )
 }
 
 /// Count the number of commits reachable from `from` but not from `hide`.

--- a/src/git_test.rs
+++ b/src/git_test.rs
@@ -1,4 +1,4 @@
-use crate::git::gather_repo_info;
+use crate::git::{self, Target, TargetKind, gather_repo_info};
 use crate::test_helpers::TestRepo;
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -248,11 +248,17 @@ fn branch_at_upstream_is_detected() {
 
 #[test]
 fn resolve_full_commit_hash() {
-    let test_repo = TestRepo::new();
-    test_repo.commit("Second commit", "file.txt");
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("Second commit");
 
     let head_oid = test_repo.head_oid();
-    let result = crate::git::resolve_target(&test_repo.repo, &head_oid.to_string());
+    let result = test_repo.in_dir(|| {
+        crate::git::resolve_arg(
+            &test_repo.repo,
+            &head_oid.to_string(),
+            &[crate::git::TargetKind::Commit],
+        )
+    });
 
     assert!(result.is_ok());
     match result.unwrap() {
@@ -266,12 +272,18 @@ fn resolve_full_commit_hash() {
 
 #[test]
 fn resolve_partial_commit_hash() {
-    let test_repo = TestRepo::new();
-    test_repo.commit("Second commit", "file.txt");
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("Second commit");
 
     let head_oid = test_repo.head_oid();
     let partial_hash = &head_oid.to_string()[..7];
-    let result = crate::git::resolve_target(&test_repo.repo, partial_hash);
+    let result = test_repo.in_dir(|| {
+        crate::git::resolve_arg(
+            &test_repo.repo,
+            partial_hash,
+            &[crate::git::TargetKind::Commit],
+        )
+    });
 
     assert!(result.is_ok());
     match result.unwrap() {
@@ -285,17 +297,218 @@ fn resolve_partial_commit_hash() {
 
 #[test]
 fn resolve_invalid_target_fails() {
-    let test_repo = TestRepo::new();
+    let test_repo = TestRepo::new_with_remote();
 
-    let result = crate::git::resolve_target(&test_repo.repo, "nonexistent");
+    let result = test_repo.in_dir(|| {
+        crate::git::resolve_arg(
+            &test_repo.repo,
+            "nonexistent",
+            &[
+                crate::git::TargetKind::Commit,
+                crate::git::TargetKind::Branch,
+                crate::git::TargetKind::File,
+            ],
+        )
+    });
 
-    // Without upstream, shortid resolution should fail because gather_repo_info fails
     assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
-    // Error should mention either "upstream" or "shortid"
     assert!(
-        err_msg.contains("upstream") || err_msg.contains("shortid"),
-        "Expected error about upstream or shortid, got: {}",
+        !err_msg.is_empty(),
+        "Expected non-empty error message, got: {}",
         err_msg
     );
+}
+
+// ── Tests for resolve_arg ───────────────────────────────────────────────
+
+#[test]
+fn resolve_arg_file_on_disk() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.write_file("hello.txt", "content");
+    test_repo.in_dir(|| {
+        let result = git::resolve_arg(&test_repo.repo, "hello.txt", &[TargetKind::File]).unwrap();
+        assert_eq!(result, Target::File("hello.txt".to_string()));
+    });
+}
+
+#[test]
+fn resolve_arg_file_cwd_relative() {
+    let test_repo = TestRepo::new_with_remote();
+    let sub_dir = test_repo.workdir().join("sub");
+    std::fs::create_dir_all(&sub_dir).unwrap();
+    std::fs::write(sub_dir.join("deep.txt"), "content").unwrap();
+    test_repo.in_dir_path(&sub_dir, || {
+        let result = git::resolve_arg(&test_repo.repo, "deep.txt", &[TargetKind::File]).unwrap();
+        assert_eq!(result, Target::File("sub/deep.txt".to_string()));
+    });
+}
+
+#[test]
+fn resolve_arg_file_not_found_errors() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.in_dir(|| {
+        let result = git::resolve_arg(&test_repo.repo, "nope.txt", &[TargetKind::File]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("file"),
+            "error should mention accepted types: {msg}"
+        );
+    });
+}
+
+#[test]
+fn resolve_arg_branch() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    let a1_oid = test_repo.head_oid();
+    test_repo.create_branch_at_commit("feature-a", a1_oid);
+    test_repo.in_dir(|| {
+        let result = git::resolve_arg(&test_repo.repo, "feature-a", &[TargetKind::Branch]).unwrap();
+        assert_eq!(result, Target::Branch("feature-a".to_string()));
+    });
+}
+
+#[test]
+fn resolve_arg_branch_not_accepted_skips() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    let a1_oid = test_repo.head_oid();
+    test_repo.create_branch_at_commit("feature-a", a1_oid);
+    test_repo.in_dir(|| {
+        // Only accept File — branch should not match
+        let result = git::resolve_arg(&test_repo.repo, "feature-a", &[TargetKind::File]);
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+fn resolve_arg_file_before_branch_wins() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    let a1_oid = test_repo.head_oid();
+    test_repo.create_branch_at_commit("collision", a1_oid);
+    test_repo.write_file("collision", "data");
+    test_repo.in_dir(|| {
+        // File first → file wins
+        let result = git::resolve_arg(
+            &test_repo.repo,
+            "collision",
+            &[TargetKind::File, TargetKind::Branch],
+        )
+        .unwrap();
+        assert_eq!(result, Target::File("collision".to_string()));
+    });
+}
+
+#[test]
+fn resolve_arg_branch_before_file_wins() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    let a1_oid = test_repo.head_oid();
+    test_repo.create_branch_at_commit("collision", a1_oid);
+    test_repo.write_file("collision", "data");
+    test_repo.in_dir(|| {
+        // Branch first → branch wins
+        let result = git::resolve_arg(
+            &test_repo.repo,
+            "collision",
+            &[TargetKind::Branch, TargetKind::File],
+        )
+        .unwrap();
+        assert_eq!(result, Target::Branch("collision".to_string()));
+    });
+}
+
+#[test]
+fn resolve_arg_commit_by_hash() {
+    let test_repo = TestRepo::new_with_remote();
+    let oid = test_repo.commit_empty("A1");
+    test_repo.in_dir(|| {
+        let result =
+            git::resolve_arg(&test_repo.repo, &oid.to_string(), &[TargetKind::Commit]).unwrap();
+        assert!(matches!(result, Target::Commit(_)));
+    });
+}
+
+#[test]
+fn resolve_arg_commit_rejects_merge() {
+    let test_repo = TestRepo::new_with_remote();
+    let upstream_oid = test_repo.find_remote_branch_target("origin/main");
+    test_repo.commit_empty("A1");
+    let a1_oid = test_repo.head_oid();
+    // Create a merge commit
+    test_repo.commit_merge("Merge side", a1_oid, upstream_oid);
+    let merge_oid = test_repo.head_oid();
+    test_repo.in_dir(|| {
+        let result = git::resolve_arg(
+            &test_repo.repo,
+            &merge_oid.to_string(),
+            &[TargetKind::Commit],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("merge commit"));
+    });
+}
+
+#[test]
+fn resolve_arg_commit_not_accepted_skips() {
+    let test_repo = TestRepo::new_with_remote();
+    let oid = test_repo.commit_empty("A1");
+    test_repo.in_dir(|| {
+        // Only accept File — commit hash should not match
+        let result = git::resolve_arg(&test_repo.repo, &oid.to_string(), &[TargetKind::File]);
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+fn resolve_arg_branch_by_shortid() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    let a1_oid = test_repo.head_oid();
+    test_repo.create_branch_at_commit("feature-a", a1_oid);
+    test_repo.in_dir(|| {
+        let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
+        let entities = info.collect_entities();
+        let alloc = crate::shortid::IdAllocator::new(entities);
+        let sid = alloc.get_branch("feature-a");
+        let result = git::resolve_arg(&test_repo.repo, &sid, &[TargetKind::Branch]).unwrap();
+        assert_eq!(result, Target::Branch("feature-a".to_string()));
+    });
+}
+
+#[test]
+fn resolve_arg_commit_by_shortid() {
+    let test_repo = TestRepo::new_with_remote();
+    let oid = test_repo.commit_empty("A1");
+    test_repo.in_dir(|| {
+        let info = git::gather_repo_info(&test_repo.repo, false, 1).unwrap();
+        let entities = info.collect_entities();
+        let alloc = crate::shortid::IdAllocator::new(entities);
+        let sid = alloc.get_commit(oid);
+        let result = git::resolve_arg(&test_repo.repo, &sid, &[TargetKind::Commit]).unwrap();
+        assert!(matches!(result, Target::Commit(_)));
+    });
+}
+
+#[test]
+fn resolve_arg_unstaged() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    test_repo.in_dir(|| {
+        let result = git::resolve_arg(&test_repo.repo, "zz", &[TargetKind::Unstaged]).unwrap();
+        assert_eq!(result, Target::Unstaged);
+    });
+}
+
+#[test]
+fn resolve_arg_unstaged_not_accepted() {
+    let test_repo = TestRepo::new_with_remote();
+    test_repo.commit_empty("A1");
+    test_repo.in_dir(|| {
+        let result = git::resolve_arg(&test_repo.repo, "zz", &[TargetKind::Commit]);
+        assert!(result.is_err());
+    });
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -106,6 +106,8 @@ pub struct RenderOpts {
     pub terminal_width: Option<u16>,
     /// Color theme for the graph output.
     pub theme: Theme,
+    /// CWD prefix relative to repo root (empty string if at root).
+    pub cwd_prefix: String,
 }
 
 /// A logical section in the rendered status output. Sections are built from
@@ -138,11 +140,17 @@ pub fn render(info: RepoInfo, opts: &RenderOpts) -> String {
 }
 
 /// Detect terminal width and build render options for the given theme.
-pub fn default_render_opts(theme: Theme) -> RenderOpts {
+pub fn default_render_opts(theme: Theme, cwd_prefix: String) -> RenderOpts {
     RenderOpts {
         terminal_width: terminal_size().map(|(Width(w), _)| w),
         theme,
+        cwd_prefix,
     }
+}
+
+/// Convert a repo-relative path to CWD-relative for display.
+fn display_path(repo_path: &str, cwd_prefix: &str) -> String {
+    crate::git::cwd_relative_path(repo_path, cwd_prefix)
 }
 
 // ── Section building ────────────────────────────────────────────────────
@@ -330,10 +338,18 @@ fn render_sections(sections: &[Section], ids: &IdAllocator, opts: &RenderOpts) -
                     idx < last_idx,
                     ids,
                     &opts.theme,
+                    &opts.cwd_prefix,
                 );
             }
             Section::Loose(commits) => {
-                render_loose(&mut out, commits, idx < last_idx, ids, &opts.theme);
+                render_loose(
+                    &mut out,
+                    commits,
+                    idx < last_idx,
+                    ids,
+                    &opts.theme,
+                    &opts.cwd_prefix,
+                );
             }
             Section::Upstream(info) => {
                 render_upstream(&mut out, info, &opts.theme);
@@ -394,7 +410,9 @@ fn render_working_changes(
                 "│".color(theme.graph),
                 ids.get_file(&change.path).color(theme.shortid).underline(),
                 "!!".color(theme.conflict).bold(),
-                change.path.color(theme.conflict).bold()
+                display_path(&change.path, &opts.cwd_prefix)
+                    .color(theme.conflict)
+                    .bold()
             )
             .unwrap();
         }
@@ -406,7 +424,7 @@ fn render_working_changes(
                 ids.get_file(&change.path).color(theme.shortid).underline(),
                 change.index.to_string().color(theme.staged),
                 change.worktree.to_string().color(theme.unstaged),
-                change.path
+                display_path(&change.path, &opts.cwd_prefix)
             )
             .unwrap();
         }
@@ -427,10 +445,10 @@ fn render_untracked(
     if untracked.len() > UNTRACKED_MULTICOLUMN_THRESHOLD
         && let Some(width) = opts.terminal_width
     {
-        render_untracked_multicolumn(out, untracked, ids, width, &opts.theme);
+        render_untracked_multicolumn(out, untracked, ids, width, &opts.theme, &opts.cwd_prefix);
         return;
     }
-    render_untracked_single_column(out, untracked, ids, &opts.theme);
+    render_untracked_single_column(out, untracked, ids, &opts.theme, &opts.cwd_prefix);
 }
 
 fn render_untracked_single_column(
@@ -438,6 +456,7 @@ fn render_untracked_single_column(
     untracked: &[&FileChange],
     ids: &IdAllocator,
     theme: &Theme,
+    cwd_prefix: &str,
 ) {
     for change in untracked {
         writeln!(
@@ -446,7 +465,7 @@ fn render_untracked_single_column(
             "│".color(theme.graph),
             ids.get_file(&change.path).color(theme.shortid).underline(),
             " ⁕".color(theme.untracked),
-            change.path
+            display_path(&change.path, cwd_prefix)
         )
         .unwrap();
     }
@@ -459,6 +478,7 @@ fn render_untracked_multicolumn(
     ids: &IdAllocator,
     term_width: u16,
     theme: &Theme,
+    cwd_prefix: &str,
 ) {
     let available = (term_width as usize).saturating_sub(GRAPH_PREFIX_WIDTH);
     let separator = "   │ "; // 5 display columns
@@ -469,7 +489,8 @@ fn render_untracked_multicolumn(
         .iter()
         .map(|f| {
             let sid = ids.get_file(&f.path);
-            sid.len() + 1 + 2 + 1 + f.path.len()
+            let disp = display_path(&f.path, cwd_prefix);
+            sid.len() + 1 + 2 + 1 + disp.len()
         })
         .collect();
 
@@ -488,13 +509,14 @@ fn render_untracked_multicolumn(
             }
             let f = untracked[idx];
             let sid = ids.get_file(&f.path);
+            let disp = display_path(&f.path, cwd_prefix);
 
             write!(
                 out,
                 "{} {} {}",
                 sid.color(theme.shortid).underline(),
                 " ⁕".color(theme.untracked),
-                f.path
+                disp
             )
             .unwrap();
 
@@ -520,6 +542,7 @@ fn render_branch(
     more_sections: bool,
     ids: &IdAllocator,
     theme: &Theme,
+    cwd_prefix: &str,
 ) {
     for (i, (name, remote)) in names.iter().enumerate() {
         let branch_id = ids.get_branch(name);
@@ -570,7 +593,7 @@ fn render_branch(
                 file_sid.color(theme.shortid).underline(),
                 file.index.to_string().color(theme.staged),
                 file.worktree.to_string().color(theme.unstaged),
-                file.path
+                display_path(&file.path, cwd_prefix)
             )
             .unwrap();
         }
@@ -591,6 +614,7 @@ fn render_loose(
     more_sections: bool,
     ids: &IdAllocator,
     theme: &Theme,
+    cwd_prefix: &str,
 ) {
     for commit in commits {
         let sid = ids.get_commit(commit.oid);
@@ -613,7 +637,7 @@ fn render_loose(
                 file_sid.color(theme.shortid).underline(),
                 file.index.to_string().color(theme.staged),
                 file.worktree.to_string().color(theme.unstaged),
-                file.path
+                display_path(&file.path, cwd_prefix)
             )
             .unwrap();
         }

--- a/src/graph_test.rs
+++ b/src/graph_test.rs
@@ -28,6 +28,7 @@ fn default_opts() -> RenderOpts {
     RenderOpts {
         terminal_width: None,
         theme: Theme::dark(),
+        cwd_prefix: String::new(),
     }
 }
 
@@ -41,6 +42,7 @@ fn render_plain_with_width(info: RepoInfo, width: u16) -> String {
     let opts = RenderOpts {
         terminal_width: Some(width),
         theme: Theme::dark(),
+        cwd_prefix: String::new(),
     };
     strip_ansi(&graph::render(info, &opts))
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -82,7 +82,7 @@ pub fn run(branch: Option<String>, no_pr: bool) -> Result<()> {
 
 /// Resolve an explicit branch argument to a woven branch name.
 fn resolve_branch(repo: &Repository, info: &git::RepoInfo, branch_arg: &str) -> Result<String> {
-    let name = git::resolve_target(repo, branch_arg)?.expect_branch()?;
+    let name = git::resolve_arg(repo, branch_arg, &[git::TargetKind::Branch])?.expect_branch()?;
     if info.branches.iter().any(|b| b.name == name) {
         Ok(name)
     } else {

--- a/src/push_test.rs
+++ b/src/push_test.rs
@@ -239,7 +239,9 @@ fn resolve_branch_rejects_commit_target() {
         &c1_oid.to_string(),
     );
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("not a commit"));
+    // With the centralized resolver, a commit hash that doesn't resolve to a branch
+    // produces a "did not resolve to a branch" error
+    assert!(result.unwrap_err().to_string().contains("branch"));
 }
 
 #[test]

--- a/src/reword.rs
+++ b/src/reword.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use git2::Repository;
 
 use crate::branch;
@@ -12,7 +12,11 @@ use crate::weave;
 pub fn run(target: String, message: Option<String>) -> Result<()> {
     let repo = git::open_repo()?;
 
-    let resolved = git::resolve_target(&repo, &target)?;
+    let resolved = git::resolve_arg(
+        &repo,
+        &target,
+        &[git::TargetKind::Branch, git::TargetKind::Commit],
+    )?;
 
     match resolved {
         Target::Commit(hash) => reword_commit(&repo, &hash, message),
@@ -37,9 +41,7 @@ pub fn run(target: String, message: Option<String>) -> Result<()> {
             git_branch::validate_name(&new_name)?;
             reword_branch(&repo, &name, &new_name)
         }
-        Target::File(_) => bail!("Cannot reword a file\nUse `git add` to stage file changes"),
-        Target::Unstaged => bail!("Cannot reword unstaged changes"),
-        Target::CommitFile { .. } => bail!("Cannot reword a commit file"),
+        _ => unreachable!(),
     }
 }
 

--- a/src/show.rs
+++ b/src/show.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 use crate::git::{self, Target};
 use crate::git_commands;
@@ -6,14 +6,16 @@ use crate::git_commands;
 /// Show the diff and metadata for a commit (like `git show`), using short IDs.
 pub fn run(target: String) -> Result<()> {
     let repo = git::open_repo()?;
-    let resolved = git::resolve_target(&repo, &target)?;
+    let resolved = git::resolve_arg(
+        &repo,
+        &target,
+        &[git::TargetKind::Commit, git::TargetKind::Branch],
+    )?;
 
     let git_ref = match resolved {
         Target::Commit(hash) => hash,
         Target::Branch(name) => name,
-        Target::File(_) => bail!("Cannot show a file\nRun `git-loom status` to see available IDs"),
-        Target::Unstaged => bail!("Cannot show unstaged changes"),
-        Target::CommitFile { .. } => bail!("Cannot show a commit file reference"),
+        _ => unreachable!(),
     };
 
     let workdir = git::require_workdir(&repo, "show")?;

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, bail};
 use git2::{Oid, Repository};
 
-use crate::git::{self, Target};
+use crate::git::{self, Target, TargetKind};
 use crate::git_commands::{self, git_commit, git_rebase};
 use crate::msg;
 use crate::weave;
@@ -21,14 +21,11 @@ fn commit_or_editor(workdir: &std::path::Path, message: Option<&str>) -> Result<
 pub fn run(target: String, message: Option<String>) -> Result<()> {
     let repo = git::open_repo()?;
 
-    let resolved = git::resolve_target(&repo, &target)?;
+    let resolved = git::resolve_arg(&repo, &target, &[TargetKind::Commit])?;
 
     match resolved {
         Target::Commit(hash) => split_commit(&repo, &hash, message),
-        Target::Branch(_) => bail!("Cannot split a branch"),
-        Target::File(_) => bail!("Cannot split a file"),
-        Target::Unstaged => bail!("Cannot split unstaged changes"),
-        Target::CommitFile { .. } => bail!("Cannot split a commit file"),
+        _ => unreachable!(),
     }
 }
 
@@ -37,11 +34,6 @@ fn split_commit(repo: &Repository, commit_hash: &str, message: Option<String>) -
     let workdir = git::require_workdir(repo, "split")?;
     let commit_oid = repo.revparse_single(commit_hash)?.peel_to_commit()?.id();
     let commit = repo.find_commit(commit_oid)?;
-
-    // Reject merge commits
-    if commit.parent_count() > 1 {
-        bail!("Cannot split a merge commit");
-    }
 
     // Get files changed in the commit
     let files = git::commit_file_paths(repo, commit_oid)?;
@@ -85,7 +77,6 @@ pub fn split_commit_with_selection(
     let commit_oid = repo.revparse_single(commit_hash)?.peel_to_commit()?.id();
     let commit = repo.find_commit(commit_oid)?;
 
-    // Reject merge commits
     if commit.parent_count() > 1 {
         bail!("Cannot split a merge commit");
     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -13,7 +13,8 @@ pub fn run(
     let repo = git::open_repo()?;
     let _ = git::require_workdir(&repo, "display status")?;
 
-    let opts = graph::default_render_opts(theme);
+    let cwd_prefix = git::cwd_relative_to_repo(&repo).unwrap_or_default();
+    let opts = graph::default_render_opts(theme, cwd_prefix);
     let show_files = file_filter.is_some();
     let mut info = git::gather_repo_info(&repo, show_files, context)?;
     if !show_all {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -303,6 +303,24 @@ impl TestRepo {
         f()
     }
 
+    /// Run a closure with CWD set to the given path (must be inside the repo).
+    pub fn in_dir_path<F, R>(&self, path: &Path, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let _lock = IN_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let restore = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        std::env::set_current_dir(path).unwrap();
+        struct RestoreDir(PathBuf);
+        impl Drop for RestoreDir {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
+        let _guard = RestoreDir(restore);
+        f()
+    }
+
     /// Switch HEAD to a branch and update the working directory.
     pub fn switch_branch(&self, name: &str) {
         self.repo.set_head(&format!("refs/heads/{}", name)).unwrap();


### PR DESCRIPTION
- Add TargetKind enum (File, Branch, Commit, CommitFile, Unstaged)
- Add resolve_arg() with two-phase resolution (direct + shortid)
- Add cwd_relative_to_repo(), cwd_to_repo_path(), repo_to_cwd_path()
- Add in_dir_path() test helper in test_helpers.rs
- Remove old resolve_target() and resolve_shortid() functions
- Migrate all callers: drop, fold, split, reword, show, push,
  branch/new, branch/unmerge, commit, absorb
- Add cwd_prefix to RenderOpts for CWD-relative file display
- Update status.rs to compute and pass CWD prefix
- Add resolve_arg tests and repo_to_cwd_path tests
- Add drop integration tests for resolver behavior
- Update specs 001, 002, 006, 007, 008, 011, 012