### PR TITLE
Fold and split can now do hunk selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,13 @@ The `specs/` directory contains detailed design documents that describe each fea
 | `specs/004-weave.md` | Weave: structured graph model for topology-aware rebase |
 | `specs/005-branch.md` | Branch creation and weaving into integration branches |
 | `specs/006-commit.md` | Commit to feature branches from the integration branch |
-| `specs/007-fold.md` | Fold: amend files, fixup commits, move commits between branches |
+| `specs/007-fold.md` | Fold: amend files, fixup commits, move commits between branches; hunk-level fold with `-p` |
 | `specs/008-drop.md` | Drop commits or branches from history |
 | `specs/009-init.md` | Initialize a new integration branch tracking a remote |
 | `specs/010-update.md` | Pull-rebase integration branch and update submodules |
 | `specs/011-push.md` | Push a feature branch to remote (plain, GitHub, Gerrit) |
 | `specs/012-absorb.md` | Absorb: auto-distribute changes into originating commits |
-| `specs/013-split.md` | Split a commit into two or more commits |
+| `specs/013-split.md` | Split a commit into two commits by file or by hunk (`-p`) |
 | `specs/014-continue-abort.md` | Continue or abort a paused loom operation |
 | `specs/015-swap.md` | Swap two commits or two branch sections |
 | `specs/016-diff.md` | Diff: short-ID–aware wrapper around git diff |

--- a/docs/src/commands/fold.md
+++ b/docs/src/commands/fold.md
@@ -7,7 +7,9 @@ Fold source(s) into a target — a polymorphic command that amends files into co
 ```
 git loom fold <target>
 git loom fold <source>... <target>
-git loom fold --patch [<files>...] <target>
+git loom fold -p [<files>...] <target>
+git loom fold -p <commit1> <commit2>
+git loom fold -p <commit> zz
 git loom fold --create <commit> <new-branch>
 ```
 
@@ -17,7 +19,7 @@ When only a target is given, currently staged files are folded into the target c
 
 | Option | Description |
 |--------|-------------|
-| `-p, --patch` | Interactively select hunks to stage, then fold them into the target commit. |
+| `-p, --patch` | Interactively select hunks before folding. Three forms depending on argument types (see below). |
 | `-c, --create` | Create a new branch and move the source commit into it. |
 
 ## Type Dispatch
@@ -77,11 +79,13 @@ If `zz` is mixed with individual file arguments, `zz` takes precedence and all c
 
 ### Interactive hunk selection (`-p`)
 
-With `-p`, an interactive TUI opens letting you pick individual hunks to fold into the target commit. The last argument is always the target commit.
+With `-p`, an interactive TUI opens for hunk-level selection. There are three forms depending on the argument types.
+
+**Form 1 — pick working-tree hunks → fold into commit:**
 
 ```bash
 git loom fold -p ab
-# Opens hunk picker for all working tree changes
+# Opens hunk picker for all working-tree changes
 # Selected hunks are staged and folded into commit ab
 ```
 
@@ -90,8 +94,27 @@ Provide file arguments before the target to narrow the picker:
 ```bash
 git loom fold -p src/auth.rs ab
 # Opens hunk picker filtered to src/auth.rs
-# Selected hunks are folded into commit ab
 ```
+
+**Form 2 — pick hunks from a commit → move into another commit:**
+
+```bash
+git loom fold -p c2 c1
+# Opens commit-diff picker for c2
+# Selected hunks are removed from c2 and added to c1
+```
+
+The source (`c2`) must be newer than the target (`c1`). Binary and deleted files are not supported.
+
+**Form 3 — pick hunks from a commit → uncommit to working tree:**
+
+```bash
+git loom fold -p ab zz
+# Opens commit-diff picker for ab
+# Selected hunks are removed from ab and appear as unstaged modifications
+```
+
+All `-p` forms error with `"No hunks selected"` if nothing is selected.
 
 ### Fixup a commit into another
 
@@ -190,9 +213,9 @@ git add <resolved-files> && git loom continue
 # ✓ Moved `d0` to branch `feature-b` (now `e1f2a3b`)
 ```
 
-The following fold operations **do not** support pause/resume and abort
-immediately on conflict:
+The following fold operations **do not** support pause/resume and abort immediately on conflict:
 
+- All `-p` (patch mode) forms — any conflict causes an automatic abort and restores the original state
 - Uncommit a single file (`CommitFile → zz`)
 - Move a file between commits (`CommitFile → Commit`)
 - Create a new branch and move a commit (`--create`)

--- a/docs/src/commands/split.md
+++ b/docs/src/commands/split.md
@@ -1,11 +1,11 @@
 # split
 
-Split a commit into two sequential commits by selecting which files go into each.
+Split a commit into two sequential commits by selecting which files (or hunks) go into the first.
 
 ## Usage
 
 ```
-git loom split <target> [-m <message>] [<files>...]
+git loom split [-p] [-m <message>] <target> [<files>...]
 ```
 
 ### Arguments
@@ -13,38 +13,37 @@ git loom split <target> [-m <message>] [<files>...]
 | Argument | Description |
 |----------|-------------|
 | `<target>` | Commit hash, short ID, or `HEAD` |
-| `<files>...` | Files for the first commit. Shows an interactive picker if omitted. |
+| `<files>...` | Files for the first commit. Shows an interactive picker if omitted. Ignored when `-p` is used. |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
 | `-m, --message <message>` | Message for the first commit. Opens editor if omitted. |
+| `-p, --patch` | Interactively pick individual hunks for the first commit |
 
 ## What It Does
 
-1. **Resolve** — finds the target commit
-2. **File selection** — if `<files>` are given, uses them directly; otherwise shows an interactive multi-select of the files changed in the commit
-3. **First commit** — creates a new commit with the selected files and the provided message (or opens the git editor if `-m` was omitted)
-4. **Second commit** — creates a second commit with the remaining files, reusing the original commit message
+### File-based split (default)
 
-### HEAD vs Non-HEAD
+Shows an interactive multi-select of all files changed in the commit. The files you pick go into the first commit; the rest stay in the second commit, which keeps the original message.
 
-- **HEAD commit**: a simple `reset --mixed` + re-commit sequence (no rebase needed)
-- **Non-HEAD commit**: uses an edit-and-continue rebase to pause at the target, split it, then replay the rest of the history
+You can skip the picker by listing `<files>` on the command line. The commit must touch at least two files.
 
-Both paths are atomic — if anything fails, the operation is aborted and the original state is restored.
+### Hunk-based split (`-p`)
 
-## Constraints
+Opens the hunk picker TUI showing every hunk in the commit. All hunks start **unselected** (no-op). Toggle hunks with `Space`; selected hunks go into the first commit, unselected hunks stay in the second. Works on single-file commits.
 
-- The commit must change **at least two files** (otherwise there is nothing to split)
-- **Merge commits** cannot be split
-- You must assign at least one file to each side (cannot put everything in one commit)
-- Branch and file targets are rejected — only commits are accepted
+### HEAD vs non-HEAD
+
+- **HEAD commit**: `reset --mixed HEAD~1` then re-commit in two steps — no rebase needed.
+- **Non-HEAD commit**: uses an edit-and-continue rebase to pause at the target, split it, then replay descendants.
+
+Both paths preserve any pre-existing staged changes and abort cleanly on error.
 
 ## Examples
 
-### Split HEAD interactively
+### Split HEAD interactively by file
 
 ```bash
 git loom split HEAD
@@ -55,24 +54,22 @@ git loom split HEAD
 # ✓ Split `abc123d` into `def456a` and `789bcd0`
 ```
 
-### Split HEAD non-interactively
+### Split HEAD by file non-interactively
 
 ```bash
 git loom split HEAD -m "refactor: extract auth" src/auth.rs
 # ✓ Split `abc123d` into `def456a` and `789bcd0`
 ```
 
-### Split a commit by short ID with a message
+### Split a commit by short ID using the hunk picker
 
 ```bash
-git loom split ab -m "refactor: extract helpers"
-# ? Select files for the first commit
-# > [x] src/helpers.rs
-#   [ ] src/lib.rs
+git loom split -p ab -m "fix: extract bounds check"
+# (hunk picker TUI opens — toggle hunks for first commit)
 # ✓ Split `ab12345` into `cd67890` and `ef01234`
 ```
 
-### Split a commit non-interactively
+### Split a non-HEAD commit by file
 
 ```bash
 git loom split ab -m "refactor: extract helpers" src/helpers.rs
@@ -82,5 +79,7 @@ git loom split ab -m "refactor: extract helpers" src/helpers.rs
 ## Prerequisites
 
 - Must be in a git repository with a working tree
-- The target commit must have at least two changed files
-- All operations are atomic and automatically preserve uncommitted changes
+- Target must be a commit (not a branch, file, or `zz`)
+- Merge commits cannot be split
+- File-based split requires the commit to touch at least two files
+- Git ≥ 2.38

--- a/specs/007-fold.md
+++ b/specs/007-fold.md
@@ -28,6 +28,9 @@ etc.). `fold` unifies them under one verb: **fold source into target**.
 git-loom fold <target>
 git-loom fold <source>... <target>
 git-loom fold --create <commit> <new-branch>
+git-loom fold -p [<files>...] <commit>
+git-loom fold -p <commit1> <commit2>
+git-loom fold -p <commit> zz
 ```
 
 **Arguments:**
@@ -51,6 +54,9 @@ all preceding arguments are sources.
   exactly one commit source. The branch is created at the upstream merge-base
   and the commit is moved into it — whether the commit was a loose commit on
   the integration line or already on an existing branch.
+- `-p` / `--patch`: Hunk-level fold mode. Opens an interactive hunk picker
+  instead of operating at the file level. Has three forms (see Patch Mode
+  below).
 
 ## Type Dispatch
 
@@ -282,6 +288,100 @@ rebase operation. The source uses the `commit_sid:index` format.
 - Commit topology
 - Other branches not in the ancestry chain
 
+## Patch Mode (`-p`)
+
+The `-p` flag switches fold to hunk-level granularity. There are three forms,
+detected by the argument types:
+
+### Form 1: Pick working-tree hunks → fold into commit
+
+```bash
+git-loom fold -p [<files>...] <commit>
+```
+
+Opens an interactive hunk picker showing the current working-tree diff,
+optionally filtered to the listed files (file paths or `zz` for all). After
+the user selects hunks, the selection is staged and folded into the target
+commit — identical in effect to `fold <staged files> <commit>` but at hunk
+granularity.
+
+**Error if no hunks selected:** `"No hunks selected"`.
+
+**What changes:**
+
+- The target commit absorbs the selected working-tree hunks (new hash).
+- All descendant commits get new hashes (same content and messages).
+
+**What stays the same:**
+
+- Unselected working-tree changes remain unstaged.
+- Other commits' content and messages.
+
+### Form 2: Pick hunks from a commit → move into another commit
+
+```bash
+git-loom fold -p <commit1> <commit2>
+```
+
+Detected when both arguments resolve to commits. Opens the commit-diff hunk
+picker for `<commit1>`. Selected hunks are removed from `<commit1>` and added
+to `<commit2>` in a single two-phase edit-and-continue rebase. `<commit1>`
+must be newer (a descendant of `<commit2>`).
+
+**Constraints:**
+
+- Source and target must be different commits.
+- Source must be newer than target: `"Source commit must be newer than target commit"`.
+- At least one hunk must be selected: `"No hunks selected"`.
+- Binary files and deleted files are not supported: `"No text hunks selected — binary and deleted files are not supported with -p"`.
+
+**What changes:**
+
+- `<commit1>` loses the selected hunks (new hash).
+- `<commit2>` gains the selected hunks (new hash).
+- All commits between/after the affected commits get new hashes.
+
+**What stays the same:**
+
+- Both commits' messages.
+- All other hunks in both commits.
+- Commit topology.
+
+### Form 3: Pick hunks from a commit → uncommit to working tree
+
+```bash
+git-loom fold -p <commit> zz
+```
+
+Detected when the target is `zz`. Opens the commit-diff hunk picker for
+`<commit>`. Selected hunks are removed from the commit and applied to the
+working directory as unstaged modifications. The commit itself remains in
+history, minus the selected hunks.
+
+**Constraints:** same as Form 2 (no binary/deleted files).
+
+**What changes:**
+
+- The commit loses the selected hunks (new hash).
+- The selected hunks appear in the working directory as unstaged modifications.
+- All descendant commits get new hashes (for non-HEAD case).
+
+**What stays the same:**
+
+- The commit's message.
+- All unselected hunks in the commit.
+- Other uncommitted changes in the working directory.
+
+### Patch mode conflict handling
+
+All `-p` forms use **hard-fail** conflict handling: if a conflict occurs during
+the internal rebase, the operation is aborted automatically and the repository
+is returned to its original state. `loom continue` / `loom abort` are not
+supported for `-p` forms.
+
+Pre-existing staged changes are always saved aside and restored regardless of
+outcome.
+
 ## Target Resolution
 
 Arguments are resolved via `resolve_arg()` with `accept = [Commit, CommitFile, File, Unstaged]` — see spec 002 for the resolution algorithm.
@@ -305,6 +405,28 @@ This means arguments can be:
 
 The command distinguishes sources from the target purely by position (last
 argument is target).
+
+## Conflict Recovery
+
+The following non-`-p` operations support resumable conflict handling (`loom
+continue` / `loom abort`):
+
+| Operation | `LoomState.context` |
+|-----------|---------------------|
+| Files into commit | `op: "FilesIntoCommit"` — original commit hash, file count, saved staged patch |
+| Commit into commit (fixup) | `op: "CommitIntoCommit"` — source and target hashes |
+| Commit to branch (move) | `op: "CommitToBranch"` — commit hash, branch name |
+| Commit to unstaged (uncommit) | `op: "CommitToUnstaged"` — commit hash, captured diff |
+
+When `loom continue` is called after conflict resolution, `after_continue`
+reads the saved context, cleans up the tracking branch (`_loom-track`), and
+prints the success message. If the `CommitToUnstaged` diff cannot be
+re-applied (because conflict resolution changed the surrounding context), the
+diff is saved to `.git/loom/unapplied.patch` for manual recovery.
+
+All `-p` (patch mode) operations use **hard-fail**: no `LoomState` is saved and
+`loom continue` / `loom abort` are not available. An auto-abort restores the
+repository on any conflict.
 
 ## Prerequisites
 
@@ -425,6 +547,43 @@ git-loom fold README.md HEAD
 # Amend README.md changes into HEAD
 ```
 
+### Fold selected working-tree hunks into a commit
+
+```bash
+git-loom status
+# │●  ab  72f9d3 Fix login bug
+# Working tree has changes to src/auth.rs
+
+git-loom fold -p ab
+# → hunk picker opens showing all working-tree changes
+# User selects specific hunks → they are staged and folded into ab
+```
+
+### Move selected hunks from one commit to another
+
+```bash
+git-loom status
+# │●  c1  aaa111 Add feature X
+# │●  c2  bbb222 Add feature Y (contains a hunk that belongs in c1)
+
+git-loom fold -p c2 c1
+# → commit-diff picker opens for c2
+# User selects the misplaced hunk → it is removed from c2 and added to c1
+# ✓ Moved hunk(s) from `bbb222` (now `ccc333`) into `aaa111` (now `ddd444`)
+```
+
+### Uncommit selected hunks to working tree
+
+```bash
+git-loom status
+# │●  ab  72f9d3 Refactor auth (too many changes mixed in)
+
+git-loom fold -p ab zz
+# → commit-diff picker opens for ab
+# User selects hunks to extract → they are removed from ab and appear unstaged
+# ✓ Uncommitted hunk(s) from `72f9d3` (now `8a3b2c`) to working directory
+```
+
 ## Design Decisions
 
 ### Single Verb, Multiple Actions
@@ -481,3 +640,21 @@ Users don't need to manually stash before folding.
 When moving a commit to a branch that shares its tip with other co-located
 branches, only the target branch advances to include the moved commit.
 Co-located branches remain unaffected, pointing at their original tip.
+
+### Patch Mode as a Flag, Not Separate Forms
+
+Hunk-level folding is exposed as `-p` on the existing `fold` command rather
+than separate commands (`fold-hunks`, `fold -h`, etc.). The three `-p` dispatch
+forms (working-tree→commit, commit→commit, commit→unstaged) mirror the
+file-level cases and keep the same "fold X into Y" mental model at finer
+granularity. Reusing `fold -p` avoids command proliferation and keeps the
+help text cohesive.
+
+### Two-Phase Rebase for Commit-to-Commit Patch Move
+
+Moving hunks between two non-HEAD commits requires two separate edit-and-continue
+rebases: phase 1 removes the selected hunks from the source commit; phase 2
+adds them to the target commit. A single rebase cannot do both atomically
+because the target commit's new OID is not known until phase 1 completes. The
+`_loom-track` temporary branch is used to carry the target commit's pre-phase-1
+OID through to phase 2.

--- a/specs/013-split.md
+++ b/specs/013-split.md
@@ -2,100 +2,242 @@
 
 ## Overview
 
-Split a single commit into two sequential commits by selecting which files belong in the first commit. The remaining files stay in the second commit, which keeps the original message.
+Split a single commit into two sequential commits by selecting which files (or
+which hunks) belong in the first commit. The remaining content stays in the
+second commit, which keeps the original message.
 
-This is the inverse of `fold` (commit + commit fixup). While file-level splitting is technically achievable with multiple `fold` commands, a dedicated `split` command with an interactive file picker provides real ergonomic value.
+## Why Split?
+
+As a change grows during development it is common to realise mid-way that the
+commit contains two distinct ideas. With raw git, separating them requires an
+interactive rebase (`edit`), `git reset HEAD~1`, hand-selecting the right files
+or hunks, committing twice, and then continuing the rebase — a multi-step
+sequence with no room for error. `loom split` compresses that into a single
+command with an interactive picker.
 
 ## CLI
 
-```
-git-loom split <target> [-m <message>] [<files>...]
+```bash
+git-loom split <target> [-m <message>] [-p] [<files>...]
 ```
 
-- **`<target>`** — Commit hash, short ID, or `HEAD`.
-- **`-m <message>`** — Message for the **first** (new) commit. If omitted, opens the git editor.
-- **`<files>...`** — Files for the **first** commit. If omitted, an interactive file picker is shown.
+**Arguments:**
 
-The **second** commit keeps the original commit message.
+- `<target>` — Commit hash, short ID, or `HEAD`.
+- `<files>...` — Files for the **first** commit (file-level split only). If
+  omitted and `-p` is not set, an interactive file picker is shown.
+
+**Flags:**
+
+- `-m <message>` — Message for the **first** (new) commit. If omitted, opens
+  the git editor.
+- `-p` / `--patch` — Hunk-level split: open a commit-diff hunk picker and
+  assign selected hunks to the first commit instead of whole files. When `-p`
+  is given, the `<files>` arguments filter which files appear in the picker.
+
+The **second** commit keeps the original commit message in both modes.
 
 ## What Happens
 
-1. **Resolve target** — Uses the shared resolution strategy (Spec 002). Must resolve to a commit (not a branch, file, or unstaged).
+### File-level split (default)
+
+1. **Resolve target** — Uses the shared resolution strategy (see Spec 002).
+   Must resolve to a commit.
 2. **Validate** — The commit must:
    - Not be a merge commit (parent count must be ≤ 1).
-   - Touch at least 2 files (a single-file commit cannot be split).
-3. **File selection** — If `<files>` are provided, use them directly. Otherwise, display an `inquire::MultiSelect` prompt listing all files changed in the commit. The user selects files for the **first** commit; the rest go into the **second** commit.
-4. **Get first commit message** — From `-m` flag or interactive prompt.
-5. **Perform the split** — Two paths depending on whether the target is HEAD:
+   - Touch at least 2 files (a single-file commit cannot be file-split; use
+     `-p` to split at the hunk level instead).
+3. **Save pre-existing staged changes** — Any staged changes are saved aside
+   so a `reset --mixed` does not discard them; they are restored regardless of
+   outcome.
+4. **File selection** — If `<files>` are provided they are used directly.
+   Otherwise an `inquire::MultiSelect` prompt lists all files changed in the
+   commit; the user picks files for the **first** commit.
+5. **Validate selection** — At least one file must remain for the second
+   commit; error if all files are selected.
+6. **Perform the split**:
+   - **HEAD path** (no rebase):
+     ```
+     reset_mixed(HEAD~1) → stage selected → commit(msg1) → stage remaining → commit(original_msg)
+     ```
+   - **Non-HEAD path** (edit-and-continue rebase):
+     ```
+     start_edit_rebase(target) → reset_mixed(HEAD~1)
+     → stage selected → commit(msg1) → stage remaining → commit(original_msg)
+     → continue_rebase_or_abort
+     ```
+7. **Print success** — `Split \`<hash>\` into \`<hash1>\` and \`<hash2>\``.
 
-### HEAD path (no rebase)
+**What changes:**
 
-```
-reset_mixed(HEAD~1)
-→ stage selected files → commit(msg1)
-→ stage remaining files → commit(original_msg)
-```
+- The target commit is replaced by two new sequential commits with new hashes.
+- All descendant commits get new hashes (same content and messages).
 
-### Non-HEAD path (edit-and-continue rebase)
+**What stays the same:**
 
-```
-Weave::from_repo → edit_commit(oid) → run_rebase (pauses at target)
-→ reset_mixed(HEAD~1)
-→ stage selected files → commit(msg1)
-→ stage remaining files → commit(original_msg)
-→ continue_rebase
-```
+- The second commit's message (original).
+- Other branches not in the ancestry chain.
+- Pre-existing staged and unstaged working-tree changes.
 
-On error after the rebase starts: `git_rebase::abort(workdir)`.
+### Hunk-level split (`-p`)
 
-6. **Print success** — `✓ Split \`<short_hash>\` into 2 commits`.
+1. **Resolve target** — Same as above; must resolve to a commit.
+2. **Validate** — The commit must not be a merge commit.
+3. **Save pre-existing staged changes** — Same as file-level split.
+4. **Hunk selection** — Opens the commit-diff hunk picker for the target
+   commit, optionally filtered to `<files>`. The user selects hunks for the
+   **first** commit.
+5. **Validate selection**:
+   - Error if no hunks selected: `"Must select at least one hunk for the first commit"`.
+   - Error if all hunks selected: `"Must leave at least one hunk for the second commit"`.
+6. **Perform the split**:
+   - **HEAD path**:
+     ```
+     reset_mixed(HEAD~1) → apply selected hunks (git apply --cached) → commit(msg1)
+     → stage remaining changes → commit(original_msg)
+     ```
+   - **Non-HEAD path** (edit-and-continue rebase):
+     ```
+     start_edit_rebase(target) → reset_mixed(HEAD~1)
+     → apply selected hunks → commit(msg1) → stage remaining → commit(original_msg)
+     → continue_rebase_or_abort
+     ```
+7. **Print success** — Same format as file-level split.
+
+**What changes / What stays the same:** same as file-level split.
+
+**Limitations with `-p`:**
+
+- Binary files and deleted files are handled at file granularity within the
+  hunk picker (the entire file is included or excluded together).
+- The `-p` mode does not save `LoomState` and does not support `loom continue`;
+  any conflict causes an immediate auto-abort.
 
 ## Target Resolution
 
-Uses the shared `git::resolve_target()` strategy. Only `Target::Commit` is accepted. All other target types produce clear error messages:
+Uses `resolve_arg()` with `accept = [Commit]`. All other target types produce
+error messages:
 
 | Target type | Error |
 |---|---|
-| `Branch` | Cannot split a branch |
-| `File` | Cannot split a file |
-| `Unstaged` | Cannot split unstaged changes |
-| `CommitFile` | Cannot split a commit file |
+| `Branch` | `"Cannot split a branch"` |
+| `File` | `"Cannot split a file"` |
+| `Unstaged` | `"Cannot split unstaged changes"` |
+| `CommitFile` | `"Cannot split a commit file"` |
+
+See Spec 002 for the resolution algorithm.
 
 ## Validation Errors
 
 | Condition | Error |
 |---|---|
-| Merge commit | Cannot split a merge commit |
-| Single-file commit | Cannot split a commit with only one file |
-| No files selected | Must select at least one file for the first commit |
-| All files selected | Must leave at least one file for the second commit |
+| Merge commit | `"Cannot split a merge commit"` |
+| Single-file commit (file mode) | `"Cannot split a commit with only one file"` |
+| No files selected | `"Must select at least one file for the second commit"` |
+| All files selected | `"Must leave at least one file for the second commit"` |
+| No hunks selected (`-p`) | `"Must select at least one hunk for the first commit"` |
+| All hunks selected (`-p`) | `"Must leave at least one hunk for the second commit"` |
+| Picker cancelled | `"Cancelled"` |
+
+## Conflict Recovery
+
+Split uses **hard-fail** conflict handling. If a conflict occurs during the
+non-HEAD rebase, the rebase is aborted automatically and the repository is
+returned to its original state. `loom continue` / `loom abort` are not
+supported for split.
+
+Pre-existing staged changes are always restored regardless of outcome.
 
 ## Prerequisites
 
-- **Git ≥ 2.38** (for `--update-refs` in interactive rebase).
-- **Working tree required** (not a bare repository).
+- Git ≥ 2.38 (for `--update-refs` in interactive rebase).
+- Working tree required (not a bare repository).
 
 ## Examples
 
-```bash
-# Split HEAD into two commits
-git loom split HEAD -m "Extract config changes"
+### Split HEAD by file
 
-# Split a commit by short ID
-git loom split 0a
+```
+git-loom status
+# ● ab  3f2a1c Add auth and config changes
+#   (touches auth.rs and config.rs)
 
-# Split a commit by hash
-git loom split abc1234
+git-loom split HEAD -m "Extract config changes"
+# → opens file picker; user selects config.rs
+# ✓ Split `3f2a1c` into `1a2b3c` and `4d5e6f`
+```
+
+### Split a non-HEAD commit by file
+
+```
+git-loom status
+# ● c1  aaa111 Add feature X and its tests
+# ● c2  bbb222 Fix typo
+
+git-loom split c1
+# → opens file picker listing src/feature.rs, tests/feature_test.rs
+# User selects src/feature.rs → prompted for message → "Add feature X"
+# Second commit keeps "Add feature X and its tests"
+```
+
+### Split HEAD by hunk
+
+```
+git-loom split HEAD -p -m "Refactor loop"
+# → opens hunk picker showing the diff of HEAD
+# User selects hunks that belong in the first commit
+# ✓ Split `3f2a1c` into `1a2b3c` and `4d5e6f`
+```
+
+### Split a non-HEAD commit by hunk
+
+```
+git-loom split 0a -p
+# → opens hunk picker for commit 0a
+# User selects hunks; editor opens for first commit message
+# ✓ Split `0a3b5c` into `1a2b3c` and `4d5e6f`
+```
+
+### Provide files on the command line (bypass picker)
+
+```
+git-loom split abc1234 -m "Add config" config.rs
+# Splits abc1234: config.rs → new commit "Add config";
+# remaining files → commit with original message
 ```
 
 ## Design Decisions
 
-1. **File-level granularity** — The split operates at the file level, not the hunk level. Hunk-level splitting would require a more complex UI and is a potential future enhancement.
+### File-level vs hunk-level granularity
 
-2. **First commit gets the new message** — The second commit keeps the original message because it represents the "remainder" of the original work. The first commit is the extracted piece that needs a new description.
+The default (file-level) split is simpler and sufficient for most cases: a
+commit that accidentally bundled two features in different files. Hunk-level
+splitting (`-p`) handles the harder case where both changes live in the same
+file. Keeping them as two modes avoids forcing hunk-picker complexity on the
+common case.
 
-3. **Optional file arguments** — Files for the first commit can be passed directly on the command line, bypassing the interactive picker. This is useful for scripting and integration testing. When no files are provided, the interactive picker is shown.
+### First commit gets the new message
 
-4. **Reuses edit-and-continue pattern** — Same approach as `reword` and `fold`: Weave-based rebase with `edit` command, manual commit manipulation, then `continue`. Falls back to linear todo for non-integration repos.
+The second commit keeps the original message because it represents the
+"remainder" of the original work. The first commit is the extracted piece that
+needs a new description.
 
-5. **Atomic operation** — If the rebase or any step fails, the operation is aborted and the repository is left unchanged.
+### Optional file arguments bypass the picker
+
+Files for the first commit can be passed directly on the command line, bypassing
+the interactive picker. This enables scripting and integration testing. When no
+files are provided (and `-p` is not set), the interactive picker is shown.
+
+### Hard-fail on conflict
+
+Split does not save `LoomState` and does not support `loom continue`. If a
+conflict arises during the non-HEAD rebase, the operation is aborted
+automatically. This was chosen because the split is always performed just after
+`edit` pauses the rebase; the user can re-run `loom split` once they have
+resolved whatever caused the conflict.
+
+### Reuses edit-and-continue pattern
+
+Same approach as `reword` and `fold`: Weave-based rebase with an `edit`
+command, manual commit manipulation, then `continue`. Falls back to a linear
+todo for non-integration repos.

--- a/src/core/staging.rs
+++ b/src/core/staging.rs
@@ -146,6 +146,8 @@ pub(crate) fn apply_selections(workdir: &Path, files: &[FileEntry]) -> Result<()
                     }
                 }
                 (HunkOrigin::Unstaged, false) => {}
+                // Commit-origin hunks are read-only here; callers handle them.
+                (HunkOrigin::Commit, _) => {}
             }
         }
 
@@ -339,6 +341,95 @@ fn collect_unstaged_hunks(
         });
     }
     Ok(false)
+}
+
+/// Open the interactive hunk picker for hunks from a specific commit.
+///
+/// Shows the diff of `oid` vs its parent. All hunks start unselected (no-op).
+/// Returns `Some(files)` with the user's selections on confirm, `None` on cancel.
+pub fn run_commit_hunk_picker(
+    workdir: &Path,
+    oid: &str,
+    files: &[String],
+    theme: &graph::Theme,
+) -> Result<Option<Vec<FileEntry>>> {
+    let entries = collect_commit_hunks(workdir, oid, files)?;
+
+    if entries.is_empty() {
+        msg::warn("No changes in commit");
+        return Ok(None);
+    }
+
+    let tui_theme = TuiTheme::from_graph_theme(theme);
+    crate::tui::hunk_selector::run_hunk_selector(entries, tui_theme)
+}
+
+/// Collect file entries from a commit's diff (`git diff <oid>^..<oid>`).
+///
+/// All hunks are created with `HunkOrigin::Commit` and `selected = false`.
+pub(crate) fn collect_commit_hunks(
+    workdir: &Path,
+    oid: &str,
+    files: &[String],
+) -> Result<Vec<FileEntry>> {
+    let changed_files = git::diff_commit_name_status(workdir, oid)?;
+
+    let mut entries = Vec::new();
+
+    for (status, path) in &changed_files {
+        if !files.is_empty() && !files.iter().any(|f| f == path) {
+            continue;
+        }
+
+        let mut hunks = Vec::new();
+        let mut is_binary = false;
+
+        if *status == 'D' {
+            hunks.push(HunkEntry {
+                hunk: diff::DiffHunk {
+                    text: String::from("(file deleted)"),
+                    modified_lines: vec![],
+                },
+                selected: false,
+                origin: HunkOrigin::Commit,
+            });
+        } else if git::diff_commit_file_is_binary(workdir, oid, path)? {
+            hunks.push(HunkEntry {
+                hunk: diff::DiffHunk {
+                    text: String::from("(binary file)"),
+                    modified_lines: vec![],
+                },
+                selected: false,
+                origin: HunkOrigin::Commit,
+            });
+            is_binary = true;
+        } else {
+            let raw_diff = git::diff_commit_file(workdir, oid, path)?;
+            for h in diff::parse_hunks(&raw_diff) {
+                hunks.push(HunkEntry {
+                    hunk: h,
+                    selected: false,
+                    origin: HunkOrigin::Commit,
+                });
+            }
+        }
+
+        if hunks.is_empty() {
+            continue;
+        }
+
+        hunks.sort_by_key(|entry| hunk_sort_key(&entry.hunk));
+
+        entries.push(FileEntry {
+            path: path.clone(),
+            hunks,
+            index_status: *status,
+            worktree_status: ' ',
+            binary: is_binary,
+        });
+    }
+
+    Ok(entries)
 }
 
 fn hunk_sort_key(hunk: &diff::DiffHunk) -> usize {

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -115,7 +115,9 @@ pub fn run(create: bool, patch: bool, args: Vec<String>, theme: &graph::Theme) -
 
     // Classify and dispatch
     match classify(&resolved_sources, &resolved_target)? {
-        FoldOp::FilesIntoCommit { files, commit } => fold_files_into_commit(&repo, &files, &commit),
+        FoldOp::FilesIntoCommit { files, commit } => {
+            fold_files_into_commit(&repo, &files, &commit, false)
+        }
         FoldOp::CommitIntoCommit { source, target } => {
             fold_commit_into_commit(&repo, &source, &target)
         }
@@ -288,7 +290,7 @@ fn run_patch_fold(repo: &Repository, args: &[String], theme: &graph::Theme) -> R
     // Fold whatever is now staged into the target commit.
     commit::verify_has_staged_changes(repo)?;
     let staged = repo::get_staged_files(repo)?;
-    fold_files_into_commit(repo, &staged, &commit_hash)
+    fold_files_into_commit(repo, &staged, &commit_hash, true)
 }
 
 /// Build a unified diff patch from the selected text hunks across all files.
@@ -564,7 +566,7 @@ fn run_staged(repo: &Repository, target_arg: &str) -> Result<()> {
     commit::verify_has_staged_changes(repo)?;
 
     let staged = repo::get_staged_files(repo)?;
-    fold_files_into_commit(repo, &staged, &commit_hash)
+    fold_files_into_commit(repo, &staged, &commit_hash, true)
 }
 
 /// The classified fold operation.
@@ -755,13 +757,23 @@ fn collect_changed_files(repo: &Repository) -> Result<Vec<String>> {
 }
 
 /// Fold file changes into a commit (Case 1: File(s) + Commit).
-fn fold_files_into_commit(repo: &Repository, files: &[String], commit_hash: &str) -> Result<()> {
+///
+/// When `skip_staging` is true the caller has already staged exactly the right
+/// content (e.g. from a hunk picker), so the file-level `git add` is skipped.
+fn fold_files_into_commit(
+    repo: &Repository,
+    files: &[String],
+    commit_hash: &str,
+    skip_staging: bool,
+) -> Result<()> {
     let workdir = repo::require_workdir(repo, "fold")?;
 
     // Validate all files have changes
-    for file in files {
-        if !repo::path_has_changes(repo, file)? {
-            bail!("File '{}' has no changes to fold", file);
+    if !skip_staging {
+        for file in files {
+            if !repo::path_has_changes(repo, file)? {
+                bail!("File '{}' has no changes to fold", file);
+            }
         }
     }
 
@@ -791,9 +803,13 @@ fn fold_files_into_commit(repo: &Repository, files: &[String], commit_hash: &str
 
     if is_head {
         // Simple case: stage files and amend HEAD
-        git::stage_files(workdir, &file_refs)?;
+        if !skip_staging {
+            git::stage_files(workdir, &file_refs)?;
+        }
         if let Err(e) = git::commit_amend_no_edit(workdir) {
-            let _ = git::unstage_files(workdir, &file_refs);
+            if !skip_staging {
+                let _ = git::unstage_files(workdir, &file_refs);
+            }
             let _ = git::restore_staged_patch(workdir, &saved_staged);
             return Err(e);
         }
@@ -808,9 +824,13 @@ fn fold_files_into_commit(repo: &Repository, files: &[String], commit_hash: &str
         let subject = target_commit.summary().unwrap_or("fixup");
         let message = format!("fixup! {}", subject);
 
-        git::stage_files(workdir, &file_refs)?;
+        if !skip_staging {
+            git::stage_files(workdir, &file_refs)?;
+        }
         if let Err(e) = git::commit(workdir, &message) {
-            let _ = git::unstage_files(workdir, &file_refs);
+            if !skip_staging {
+                let _ = git::unstage_files(workdir, &file_refs);
+            }
             let _ = git::restore_staged_patch(workdir, &saved_staged);
             return Err(e);
         }

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::commit;
+use crate::core::diff;
 use crate::core::graph;
 use crate::core::msg;
 use crate::core::repo::{self, Target, TargetKind};
@@ -11,6 +12,7 @@ use crate::core::staging;
 use crate::core::transaction::{self, LoomState, Rollback};
 use crate::core::weave::{self, RebaseOutcome, Weave};
 use crate::git;
+use crate::tui::hunk_selector::FileEntry;
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "op")]
@@ -215,18 +217,43 @@ fn create_branch_and_move(
     Ok(())
 }
 
-/// Fold interactively-selected hunks into a target commit.
+/// Fold interactively-selected hunks into a target commit, or move/uncommit
+/// hunks from a source commit.
 ///
-/// `args` is `[<target>]` or `[<files...>, <target>]`.
-/// The last argument is the target commit; all others are file filters for the
-/// hunk picker. If no files are given, all working-tree changes are shown.
+/// Forms:
+/// - `fold -p [<files>...] <commit>` — pick working-tree hunks, fold into commit
+/// - `fold -p <commit1> <commit2>` — pick hunks from commit1 to move into commit2
+/// - `fold -p <commit> zz` — pick hunks from commit to uncommit to working tree
 fn run_patch_fold(repo: &Repository, args: &[String], theme: &graph::Theme) -> Result<()> {
     let workdir = repo::require_workdir(repo, "fold")?;
 
-    let (target_arg, file_args) = args.split_last().expect("args is non-empty");
+    let (target_arg, source_args) = args.split_last().expect("args is non-empty");
 
-    // Validate file args: reject commit / branch sources (out of scope for -p).
-    for arg in file_args {
+    // Detect commit-source forms: fold -p <commit> <commit|zz>
+    if source_args.len() == 1 {
+        let source_arg = &source_args[0];
+        if let Ok(Target::Commit(source_hash)) =
+            repo::resolve_arg(repo, source_arg, &[TargetKind::Commit])
+        {
+            if target_arg == "zz" {
+                return run_patch_fold_commit_to_unstaged(repo, workdir, &source_hash, theme);
+            }
+            if let Ok(Target::Commit(target_hash)) =
+                repo::resolve_arg(repo, target_arg, &[TargetKind::Commit])
+            {
+                return run_patch_fold_commit_to_commit(
+                    repo,
+                    workdir,
+                    &source_hash,
+                    &target_hash,
+                    theme,
+                );
+            }
+        }
+    }
+
+    // Working-tree hunk fold: validate sources are files/zz (not commits/branches).
+    for arg in source_args {
         if arg == "zz" {
             continue;
         }
@@ -251,8 +278,8 @@ fn run_patch_fold(repo: &Repository, args: &[String], theme: &graph::Theme) -> R
         _ => unreachable!(),
     };
 
-    // Open the hunk picker (filtered to file_args if provided, else all changes).
-    let confirmed = staging::run_hunk_picker(repo, workdir, file_args, theme)?;
+    // Open the hunk picker (filtered to source_args if provided, else all changes).
+    let confirmed = staging::run_hunk_picker(repo, workdir, source_args, theme)?;
     if !confirmed {
         msg::error("Fold cancelled");
         return Ok(());
@@ -262,6 +289,265 @@ fn run_patch_fold(repo: &Repository, args: &[String], theme: &graph::Theme) -> R
     commit::verify_has_staged_changes(repo)?;
     let staged = repo::get_staged_files(repo)?;
     fold_files_into_commit(repo, &staged, &commit_hash)
+}
+
+/// Build a unified diff patch from the selected text hunks across all files.
+fn build_selected_patch(selections: &[FileEntry]) -> String {
+    let mut patch = String::new();
+    for file in selections {
+        if file.binary {
+            continue;
+        }
+        let selected: Vec<_> = file
+            .hunks
+            .iter()
+            .filter(|h| h.selected)
+            .map(|h| &h.hunk)
+            .collect();
+        if !selected.is_empty() {
+            patch.push_str(&diff::build_hunk_patch(&file.path, &selected));
+        }
+    }
+    patch
+}
+
+/// At a rebase edit pause: reverse-apply patch, stage affected files, amend.
+fn reverse_apply_and_amend(workdir: &Path, selections: &[FileEntry], patch: &str) -> Result<()> {
+    git::apply_patch_reverse(workdir, patch)?;
+    for file in selections {
+        if file.hunks.iter().any(|h| h.selected) {
+            git::stage_path(workdir, &file.path)?;
+        }
+    }
+    git::commit_amend_no_edit(workdir)
+}
+
+/// At a rebase edit pause: apply patch, stage affected files, amend.
+fn apply_and_amend(workdir: &Path, selections: &[FileEntry], patch: &str) -> Result<()> {
+    git::apply_patch(workdir, patch)?;
+    for file in selections {
+        if file.hunks.iter().any(|h| h.selected) {
+            git::stage_path(workdir, &file.path)?;
+        }
+    }
+    git::commit_amend_no_edit(workdir)
+}
+
+/// Pick hunks from `source_hash` to move into `target_hash`.
+///
+/// Selected hunks are removed from source and added to target via a two-phase
+/// edit+continue rebase. Requires source to be newer than target.
+fn run_patch_fold_commit_to_commit(
+    repo: &Repository,
+    workdir: &Path,
+    source_hash: &str,
+    target_hash: &str,
+    theme: &graph::Theme,
+) -> Result<()> {
+    let source_oid = git2::Oid::from_str(source_hash)?;
+    let target_oid = git2::Oid::from_str(target_hash)?;
+
+    if source_oid == target_oid {
+        bail!("Source and target are the same commit");
+    }
+    if !repo.graph_descendant_of(source_oid, target_oid)? {
+        bail!("Source commit must be newer than target commit");
+    }
+
+    let selections = staging::run_commit_hunk_picker(workdir, source_hash, &[], theme)?
+        .ok_or_else(|| anyhow::anyhow!("Cancelled"))?;
+
+    if !selections
+        .iter()
+        .any(|f| f.hunks.iter().any(|h| h.selected))
+    {
+        bail!("No hunks selected");
+    }
+
+    let selected_patch = build_selected_patch(&selections);
+    if selected_patch.is_empty() {
+        bail!("No text hunks selected — binary and deleted files are not supported with -p");
+    }
+
+    let saved_head = repo::head_oid(repo)?.to_string();
+    let saved_refs = repo::snapshot_branch_refs(repo)?;
+
+    // Save and unstage any pre-existing staged changes so they don't accidentally
+    // get included in the amend operations below.
+    let saved_staged = save_and_unstage_all_staged(repo, workdir)?;
+
+    // Phase 1: edit source, remove selected hunks.
+    let mut graph = Weave::from_repo(repo)?;
+    graph.edit_commit(source_oid);
+    let todo = graph.to_todo();
+    git::branch_force_create(workdir, TRACK_BRANCH, target_hash)?;
+
+    if let Err(e) = weave::run_rebase_or_abort(workdir, Some(&graph.base_oid.to_string()), &todo) {
+        let _ = git::branch_delete(workdir, TRACK_BRANCH);
+        let _ = git::restore_staged_patch(workdir, &saved_staged);
+        return Err(e);
+    }
+
+    if let Err(e) = reverse_apply_and_amend(workdir, &selections, &selected_patch) {
+        let _ = git::rebase_abort(workdir);
+        let _ = git::branch_delete(workdir, TRACK_BRANCH);
+        let _ = git::restore_staged_patch(workdir, &saved_staged);
+        return Err(e);
+    }
+
+    let new_source_hash = git::rev_parse(workdir, "HEAD")?;
+
+    if let Err(e) = git::continue_rebase_or_abort(workdir) {
+        let _ = git::branch_delete(workdir, TRACK_BRANCH);
+        let _ = git::restore_staged_patch(workdir, &saved_staged);
+        return Err(e);
+    }
+
+    // Phase 2: edit target (new OID tracked via TRACK_BRANCH), add selected hunks.
+    let phase2_target_hash = git::rev_parse(workdir, TRACK_BRANCH)?;
+    let _ = git::branch_delete(workdir, TRACK_BRANCH);
+    let phase2_target_oid = git2::Oid::from_str(&phase2_target_hash)?;
+
+    let repo2 = git2::Repository::discover(workdir)?;
+    let mut graph2 = Weave::from_repo(&repo2)?;
+    graph2.edit_commit(phase2_target_oid);
+    let todo2 = graph2.to_todo();
+
+    let rollback = |saved_head: &str, saved_refs: &std::collections::HashMap<String, git2::Oid>| {
+        let _ = git::reset_hard(workdir, saved_head);
+        if let Err(re) = repo::restore_branch_refs(workdir, saved_refs) {
+            msg::warn(&format!("failed to restore branch refs: {re}"));
+        }
+    };
+
+    if let Err(e) = weave::run_rebase_or_abort(workdir, Some(&graph2.base_oid.to_string()), &todo2)
+    {
+        rollback(&saved_head, &saved_refs);
+        let _ = git::restore_staged_patch(workdir, &saved_staged);
+        return Err(e);
+    }
+
+    if let Err(e) = apply_and_amend(workdir, &selections, &selected_patch) {
+        let _ = git::rebase_abort(workdir);
+        rollback(&saved_head, &saved_refs);
+        let _ = git::restore_staged_patch(workdir, &saved_staged);
+        return Err(e);
+    }
+
+    let new_target_hash = git::rev_parse(workdir, "HEAD")?;
+
+    if let Err(e) = git::continue_rebase_or_abort(workdir) {
+        rollback(&saved_head, &saved_refs);
+        let _ = git::restore_staged_patch(workdir, &saved_staged);
+        return Err(e);
+    }
+
+    git::restore_staged_patch(workdir, &saved_staged)?;
+
+    msg::success(&format!(
+        "Moved hunk(s) from `{}` (now `{}`) into `{}` (now `{}`)",
+        git::short_hash(source_hash),
+        git::short_hash(&new_source_hash),
+        git::short_hash(target_hash),
+        git::short_hash(&new_target_hash)
+    ));
+
+    Ok(())
+}
+
+/// Pick hunks from `commit_hash` to uncommit back into the working tree.
+///
+/// Selected hunks are removed from the commit and left unstaged.
+fn run_patch_fold_commit_to_unstaged(
+    repo: &Repository,
+    workdir: &Path,
+    commit_hash: &str,
+    theme: &graph::Theme,
+) -> Result<()> {
+    let selections = staging::run_commit_hunk_picker(workdir, commit_hash, &[], theme)?
+        .ok_or_else(|| anyhow::anyhow!("Cancelled"))?;
+
+    if !selections
+        .iter()
+        .any(|f| f.hunks.iter().any(|h| h.selected))
+    {
+        bail!("No hunks selected");
+    }
+
+    let selected_patch = build_selected_patch(&selections);
+    if selected_patch.is_empty() {
+        bail!("No text hunks selected — binary and deleted files are not supported with -p");
+    }
+
+    let head_oid = repo::head_oid(repo)?;
+    let target_oid = git2::Oid::from_str(commit_hash)?;
+    let is_head = head_oid == target_oid;
+
+    // Save and unstage any pre-existing staged changes so they don't accidentally
+    // get included in the amend operation below.
+    let saved_staged = save_and_unstage_all_staged(repo, workdir)?;
+
+    let new_hash;
+
+    if is_head {
+        let pre_amend_hash = head_oid.to_string();
+        git::apply_patch_reverse(workdir, &selected_patch)?;
+        for file in &selections {
+            if file.hunks.iter().any(|h| h.selected) {
+                git::stage_path(workdir, &file.path)?;
+            }
+        }
+        git::commit_amend_no_edit(workdir)?;
+        new_hash = git::rev_parse(workdir, "HEAD")?;
+        if let Err(e) = git::apply_patch(workdir, &selected_patch) {
+            let _ = git::reset_hard(workdir, &pre_amend_hash);
+            let _ = git::restore_staged_patch(workdir, &saved_staged);
+            return Err(e)
+                .context("Failed to restore hunks to working directory, operation rolled back");
+        }
+    } else {
+        let saved_head = head_oid.to_string();
+        let saved_refs = repo::snapshot_branch_refs(repo)?;
+
+        let mut graph = Weave::from_repo(repo)?;
+        graph.edit_commit(target_oid);
+        let todo = graph.to_todo();
+        if let Err(e) =
+            weave::run_rebase_or_abort(workdir, Some(&graph.base_oid.to_string()), &todo)
+        {
+            let _ = git::restore_staged_patch(workdir, &saved_staged);
+            return Err(e);
+        }
+
+        if let Err(e) = reverse_apply_and_amend(workdir, &selections, &selected_patch) {
+            let _ = git::rebase_abort(workdir);
+            let _ = git::restore_staged_patch(workdir, &saved_staged);
+            return Err(e);
+        }
+
+        new_hash = git::rev_parse(workdir, "HEAD")?;
+        git::continue_rebase_or_abort(workdir)?;
+
+        if let Err(e) = git::apply_patch(workdir, &selected_patch) {
+            let _ = git::reset_hard(workdir, &saved_head);
+            if let Err(re) = repo::restore_branch_refs(workdir, &saved_refs) {
+                msg::warn(&format!("failed to restore branch refs: {re}"));
+            }
+            let _ = git::restore_staged_patch(workdir, &saved_staged);
+            return Err(e)
+                .context("Failed to apply changes to working directory, operation rolled back");
+        }
+    }
+
+    git::restore_staged_patch(workdir, &saved_staged)?;
+
+    msg::success(&format!(
+        "Uncommitted hunk(s) from `{}` (now `{}`) to working directory",
+        git::short_hash(commit_hash),
+        git::short_hash(&new_hash)
+    ));
+
+    Ok(())
 }
 
 /// Fold currently staged files into a target commit.
@@ -436,6 +722,22 @@ fn classify(sources: &[Target], target: &Target) -> Result<FoldOp> {
             _ => unreachable!(),
         }
     }
+}
+
+/// Save and unstage all currently staged changes, returning a patch to restore them later.
+///
+/// Returns an empty string if nothing is staged. Callers must call
+/// `git::restore_staged_patch` with the returned patch when the operation
+/// completes (or is rolled back), so pre-existing staged work is never lost.
+fn save_and_unstage_all_staged(repo: &Repository, workdir: &Path) -> Result<String> {
+    let staged = repo::get_staged_files(repo)?;
+    if staged.is_empty() {
+        return Ok(String::new());
+    }
+    let refs: Vec<&str> = staged.iter().map(|s| s.as_str()).collect();
+    let patch = git::diff_cached_files(workdir, &refs)?;
+    git::unstage_files(workdir, &refs)?;
+    Ok(patch)
 }
 
 /// Collect all file paths with staged or unstaged changes.

--- a/src/fold_test.rs
+++ b/src/fold_test.rs
@@ -19,6 +19,7 @@ fn fold_file_into_head() {
         &test_repo.repo,
         &["file1.txt".to_string()],
         &head_oid.to_string(),
+        false,
     );
 
     assert!(
@@ -50,6 +51,7 @@ fn fold_multiple_files_into_head() {
         &test_repo.repo,
         &["file1.txt".to_string(), "new_file.txt".to_string()],
         &head_oid.to_string(),
+        false,
     );
 
     assert!(result.is_ok(), "fold failed: {:?}", result);
@@ -71,6 +73,7 @@ fn fold_file_into_non_head_commit() {
         &test_repo.repo,
         &["file1.txt".to_string()],
         &c1_oid.to_string(),
+        false,
     );
 
     assert!(
@@ -99,6 +102,7 @@ fn fold_file_no_changes_fails() {
         &test_repo.repo,
         &["file1.txt".to_string()],
         &head_oid.to_string(),
+        false,
     );
 
     assert!(result.is_err());
@@ -119,6 +123,7 @@ fn fold_file_into_non_head_with_other_changes_autostashed() {
         &test_repo.repo,
         &["file1.txt".to_string()],
         &c1_oid.to_string(),
+        false,
     );
 
     assert!(
@@ -159,6 +164,7 @@ fn fold_file_into_woven_branch_commit() {
         &test_repo.repo,
         &["feature1".to_string()],
         &feat1_oid.to_string(),
+        false,
     );
 
     assert!(
@@ -180,6 +186,132 @@ fn fold_file_into_woven_branch_commit() {
         !status_output.contains("UU") && !status_output.contains("AA"),
         "Working tree should have no merge conflicts, but status shows:\n{}",
         status_output
+    );
+}
+
+// ── Case 1b: fold -p (skip_staging=true) — hunk-level precision ─────────
+
+/// Read the content of a file from a specific commit tree.
+fn read_file_from_commit(repo: &git2::Repository, commit_oid: git2::Oid, path: &str) -> String {
+    let commit = repo.find_commit(commit_oid).unwrap();
+    let tree = commit.tree().unwrap();
+    let entry = tree.get_path(std::path::Path::new(path)).unwrap();
+    let blob = repo.find_blob(entry.id()).unwrap();
+    std::str::from_utf8(blob.content()).unwrap().to_string()
+}
+
+/// Regression test: `fold -p <commit>` must fold only staged hunks, not entire files.
+///
+/// Before the fix, `fold_files_into_commit` called `git stage_files` which
+/// re-staged the whole file, overwriting the hunk-level staging set by
+/// `apply_selections`.  With `skip_staging = true` the precise staging must be
+/// preserved.
+#[test]
+fn fold_patch_only_staged_hunk_is_folded_into_head() {
+    let test_repo = TestRepo::new();
+
+    // Initial file with enough gap between sections to produce two hunks.
+    let initial = "line 1\nline 2\nline 3\nline 4\nline 5\n\
+                   line 6\nline 7\nline 8\nline 9\nline 10\n\
+                   line 11\nline 12\nline 13\nline 14\nline 15\n";
+    test_repo.write_file("file.txt", initial);
+    test_repo.stage_files(&["file.txt"]);
+    test_repo.commit_staged("initial");
+
+    // Modify two distant regions — produces two separate hunks.
+    let modified = "line 1\nMODIFIED TOP\nline 3\nline 4\nline 5\n\
+                    line 6\nline 7\nline 8\nline 9\nline 10\n\
+                    line 11\nline 12\nline 13\nMODIFIED BOTTOM\nline 15\n";
+    test_repo.write_file("file.txt", modified);
+
+    // Stage only the first hunk (top change) by applying a patch to the index.
+    let first_hunk_patch = "--- a/file.txt\n+++ b/file.txt\n\
+                             @@ -1,5 +1,5 @@\n line 1\n-line 2\n+MODIFIED TOP\n \
+                             line 3\n line 4\n line 5\n";
+    let workdir = test_repo.workdir();
+    crate::git::apply_cached_patch(workdir.as_path(), first_hunk_patch).unwrap();
+
+    let head_oid = test_repo.head_oid();
+    let staged = crate::core::repo::get_staged_files(&test_repo.repo).unwrap();
+    assert_eq!(staged, vec!["file.txt"]);
+
+    let result =
+        super::fold_files_into_commit(&test_repo.repo, &staged, &head_oid.to_string(), true);
+    assert!(
+        result.is_ok(),
+        "fold_files_into_commit failed: {:?}",
+        result
+    );
+
+    // The committed file must contain only the first hunk — not MODIFIED BOTTOM.
+    let committed = read_file_from_commit(&test_repo.repo, test_repo.head_oid(), "file.txt");
+    assert!(
+        committed.contains("MODIFIED TOP"),
+        "committed content should contain MODIFIED TOP"
+    );
+    assert!(
+        !committed.contains("MODIFIED BOTTOM"),
+        "committed content must NOT contain MODIFIED BOTTOM (whole-file bug)"
+    );
+
+    // The second change must still be in the working tree (not lost).
+    let worktree = test_repo.read_file("file.txt");
+    assert!(
+        worktree.contains("MODIFIED BOTTOM"),
+        "working tree should still have MODIFIED BOTTOM"
+    );
+}
+
+/// Same regression but targeting a non-HEAD commit.
+#[test]
+fn fold_patch_only_staged_hunk_is_folded_into_non_head() {
+    let test_repo = TestRepo::new_with_remote();
+
+    let initial = "line 1\nline 2\nline 3\nline 4\nline 5\n\
+                   line 6\nline 7\nline 8\nline 9\nline 10\n\
+                   line 11\nline 12\nline 13\nline 14\nline 15\n";
+    test_repo.write_file("file.txt", initial);
+    test_repo.stage_files(&["file.txt"]);
+    test_repo.commit_staged("target commit");
+    let target_oid = test_repo.head_oid();
+
+    // Add a second commit on top using CLI helpers to avoid index sync issues.
+    test_repo.write_file("other.txt", "other content");
+    test_repo.stage_files(&["other.txt"]);
+    test_repo.commit_staged("second commit");
+
+    // Modify two distant regions.
+    let modified = "line 1\nMODIFIED TOP\nline 3\nline 4\nline 5\n\
+                    line 6\nline 7\nline 8\nline 9\nline 10\n\
+                    line 11\nline 12\nline 13\nMODIFIED BOTTOM\nline 15\n";
+    test_repo.write_file("file.txt", modified);
+
+    // Stage only the first hunk.
+    let first_hunk_patch = "--- a/file.txt\n+++ b/file.txt\n\
+                             @@ -1,5 +1,5 @@\n line 1\n-line 2\n+MODIFIED TOP\n \
+                             line 3\n line 4\n line 5\n";
+    let workdir = test_repo.workdir();
+    crate::git::apply_cached_patch(workdir.as_path(), first_hunk_patch).unwrap();
+
+    let staged = crate::core::repo::get_staged_files(&test_repo.repo).unwrap();
+    let result =
+        super::fold_files_into_commit(&test_repo.repo, &staged, &target_oid.to_string(), true);
+    assert!(
+        result.is_ok(),
+        "fold_files_into_commit failed: {:?}",
+        result
+    );
+
+    // Find the new OID of the rewritten target commit (it's now 1 step back).
+    let new_target_oid = test_repo.get_oid(1);
+    let committed = read_file_from_commit(&test_repo.repo, new_target_oid, "file.txt");
+    assert!(
+        committed.contains("MODIFIED TOP"),
+        "committed content should contain MODIFIED TOP"
+    );
+    assert!(
+        !committed.contains("MODIFIED BOTTOM"),
+        "committed content must NOT contain MODIFIED BOTTOM (whole-file bug)"
     );
 }
 
@@ -1590,6 +1722,7 @@ fn fold_abort_preserves_working_state() {
         &test_repo.repo,
         &["shared.txt".to_string()],
         &a_oid.to_string(),
+        false,
     );
     assert!(
         result.is_ok(),

--- a/src/git/git_diff.rs
+++ b/src/git/git_diff.rs
@@ -85,6 +85,59 @@ pub fn diff_cached_file_is_binary(workdir: &Path, path: &str) -> Result<bool> {
     Ok(out.starts_with("-\t"))
 }
 
+/// Check whether a file's changes within a commit are binary.
+///
+/// Uses `git diff --numstat <oid>^..<oid> -- <path>`.
+pub fn diff_commit_file_is_binary(workdir: &Path, oid: &str, path: &str) -> Result<bool> {
+    let out = run_git_stdout(
+        workdir,
+        &[
+            "diff",
+            "--numstat",
+            &format!("{}^..{}", oid, oid),
+            "--",
+            path,
+        ],
+    )?;
+    Ok(out.starts_with("-\t"))
+}
+
+/// List files changed in a commit with their status character (A/M/D/R/etc.).
+///
+/// Wraps `git diff --name-status <oid>^..<oid>`. Returns `(status_char, path)` pairs.
+pub fn diff_commit_name_status(workdir: &Path, oid: &str) -> Result<Vec<(char, String)>> {
+    let out = run_git_stdout(
+        workdir,
+        &["diff", "--name-status", &format!("{}^..{}", oid, oid)],
+    )?;
+    let mut result = Vec::new();
+    for line in out.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut fields = line.splitn(2, '\t');
+        let status_field = fields.next().unwrap_or("");
+        let path_field = fields.next().unwrap_or("").trim();
+        if status_field.is_empty() || path_field.is_empty() {
+            continue;
+        }
+        let status = status_field.chars().next().unwrap_or('M');
+        // For rename/copy entries (R/C), git outputs "old-path\tnew-path"; use the destination.
+        let path = if matches!(status, 'R' | 'C') {
+            path_field
+                .split('\t')
+                .next_back()
+                .unwrap_or(path_field)
+                .to_string()
+        } else {
+            path_field.to_string()
+        };
+        result.push((status, path));
+    }
+    Ok(result)
+}
+
 /// Get the full unified diff of all working-tree changes against HEAD.
 ///
 /// Wraps `git diff HEAD`.

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -19,8 +19,8 @@ pub use git_commit::{
 };
 pub use git_diff::{
     diff_cached_file, diff_cached_file_is_binary, diff_cached_files, diff_commit, diff_commit_file,
-    diff_file, diff_file_is_binary, diff_head, diff_head_file, diff_head_file_is_binary,
-    diff_head_files, diff_head_name_only,
+    diff_commit_file_is_binary, diff_commit_name_status, diff_file, diff_file_is_binary, diff_head,
+    diff_head_file, diff_head_file_is_binary, diff_head_files, diff_head_name_only,
 };
 pub use git_merge::{MergeOutcome, continue_merge, merge_abort, merge_is_in_progress, merge_no_ff};
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,9 @@ enum Command {
         /// Message for the first commit (prompts if omitted)
         #[arg(short, long)]
         message: Option<String>,
+        /// Interactively pick hunks for the first commit
+        #[arg(short = 'p', long = "patch")]
+        patch: bool,
         /// Files for the first commit (shows interactive picker if omitted)
         files: Vec<String>,
     },
@@ -432,8 +435,9 @@ fn main() {
         Some(Command::Split {
             target,
             message,
+            patch,
             files,
-        }) => split::run(target, message, files),
+        }) => split::run(target, message, patch, files, &theme),
         Some(Command::Push { branch, no_pr }) => push::run(branch, no_pr),
         Some(Command::Update { yes }) => update::run(yes),
         Some(Command::Fold {

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,10 +1,11 @@
 use anyhow::{Result, bail};
 use git2::{Oid, Repository};
 
-use crate::core::msg;
 use crate::core::repo::{self, Target, TargetKind};
 use crate::core::weave;
+use crate::core::{diff, graph, msg, staging};
 use crate::git;
+use crate::tui::hunk_selector::FileEntry;
 
 /// Commit with `-m` message or open the editor.
 fn commit_or_editor(workdir: &std::path::Path, message: Option<&str>) -> Result<()> {
@@ -17,14 +18,20 @@ fn commit_or_editor(workdir: &std::path::Path, message: Option<&str>) -> Result<
 /// Split a commit into two sequential commits.
 ///
 /// Dispatches based on the resolved target type:
-/// - Commit → split the commit by selecting files for the first commit
-pub fn run(target: String, message: Option<String>, files: Vec<String>) -> Result<()> {
+/// - Commit → split the commit by selecting files (or hunks with `-p`) for the first commit
+pub fn run(
+    target: String,
+    message: Option<String>,
+    patch: bool,
+    files: Vec<String>,
+    theme: &graph::Theme,
+) -> Result<()> {
     let repo = repo::open_repo()?;
 
     let resolved = repo::resolve_arg(&repo, &target, &[TargetKind::Commit])?;
 
     match resolved {
-        Target::Commit(hash) => split_commit(&repo, &hash, message, files),
+        Target::Commit(hash) => split_commit(&repo, &hash, message, patch, files, theme),
         _ => unreachable!(),
     }
 }
@@ -34,7 +41,9 @@ fn split_commit(
     repo: &Repository,
     commit_hash: &str,
     message: Option<String>,
+    patch: bool,
     files: Vec<String>,
+    theme: &graph::Theme,
 ) -> Result<()> {
     let workdir = repo::require_workdir(repo, "split")?;
     let commit_oid = repo.revparse_single(commit_hash)?.peel_to_commit()?.id();
@@ -44,7 +53,37 @@ fn split_commit(
         bail!("Cannot split a merge commit");
     }
 
-    // Get files changed in the commit
+    let original_msg = commit.message().unwrap_or("").trim().to_string();
+
+    if patch {
+        let oid_str = commit_oid.to_string();
+        let selections = staging::run_commit_hunk_picker(workdir, &oid_str, &files, theme)?
+            .ok_or_else(|| anyhow::anyhow!("Cancelled"))?;
+
+        let has_selected = selections
+            .iter()
+            .any(|f| f.hunks.iter().any(|h| h.selected));
+        let has_unselected = selections
+            .iter()
+            .any(|f| f.hunks.iter().any(|h| !h.selected));
+        if !has_selected {
+            bail!("Must select at least one hunk for the first commit");
+        }
+        if !has_unselected {
+            bail!("Must leave at least one hunk for the second commit");
+        }
+
+        return perform_split_by_hunks(
+            repo,
+            workdir,
+            commit_oid,
+            &selections,
+            message.as_deref(),
+            &original_msg,
+        );
+    }
+
+    // File-based split
     let all_files = repo::commit_file_paths(repo, commit_oid)?;
     if all_files.len() < 2 {
         bail!("Cannot split a commit with only one file");
@@ -60,9 +99,6 @@ fn split_commit(
         files
     };
 
-    let original_msg = commit.message().unwrap_or("").trim().to_string();
-
-    // Compute remaining files
     let remaining: Vec<String> = all_files
         .into_iter()
         .filter(|f| !selected.contains(f))
@@ -89,7 +125,8 @@ pub fn split_commit_with_selection(
     selected: Vec<String>,
     message: String,
 ) -> Result<()> {
-    split_commit(repo, commit_hash, Some(message), selected)
+    let theme = graph::Theme::dark();
+    split_commit(repo, commit_hash, Some(message), false, selected, &theme)
 }
 
 /// Show an interactive file picker for splitting.
@@ -220,6 +257,114 @@ fn perform_non_head_split(
     // Abort automatically on conflict — split does not save LoomState.
     git::continue_rebase_or_abort(workdir)?;
 
+    Ok((hash1, hash2))
+}
+
+/// Perform the hunk-based split operation.
+fn perform_split_by_hunks(
+    repo: &Repository,
+    workdir: &std::path::Path,
+    commit_oid: Oid,
+    selections: &[FileEntry],
+    msg1: Option<&str>,
+    msg2: &str,
+) -> Result<()> {
+    let head_oid = repo::head_oid(repo)?;
+    let is_head = head_oid == commit_oid;
+    let oid_str = commit_oid.to_string();
+    let short_hash = git::short_hash(&oid_str);
+
+    let saved_staged = save_staged(repo, workdir)?;
+
+    let split_result = if is_head {
+        perform_head_split_by_hunks(workdir, selections, msg1, msg2)
+    } else {
+        perform_non_head_split_by_hunks(repo, workdir, commit_oid, selections, msg1, msg2)
+    };
+
+    git::restore_staged_patch(workdir, &saved_staged)?;
+
+    let (new_hash1, new_hash2) = split_result?;
+
+    msg::success(&format!(
+        "Split `{}` into `{}` and `{}`",
+        short_hash,
+        git::short_hash(&new_hash1),
+        git::short_hash(&new_hash2)
+    ));
+    Ok(())
+}
+
+/// HEAD hunk-based split.
+///
+/// ```text
+/// reset_mixed(HEAD~1) → apply selected hunks → commit(msg1) → stage remaining → commit(msg2)
+/// ```
+fn perform_head_split_by_hunks(
+    workdir: &std::path::Path,
+    selections: &[FileEntry],
+    msg1: Option<&str>,
+    msg2: &str,
+) -> Result<(String, String)> {
+    git::reset_mixed(workdir, "HEAD~1")?;
+
+    // Stage selected hunks for the first commit.
+    let mut selected_patch = String::new();
+    for file in selections {
+        let selected: Vec<_> = file
+            .hunks
+            .iter()
+            .filter(|h| h.selected)
+            .map(|h| &h.hunk)
+            .collect();
+        if selected.is_empty() {
+            continue;
+        }
+        if file.binary || file.index_status == 'D' {
+            git::stage_path(workdir, &file.path)?;
+        } else {
+            selected_patch.push_str(&diff::build_hunk_patch(&file.path, &selected));
+        }
+    }
+    if !selected_patch.is_empty() {
+        git::apply_cached_patch(workdir, &selected_patch)?;
+    }
+
+    commit_or_editor(workdir, msg1)?;
+
+    // Stage remaining changes for the second commit.
+    for file in selections {
+        if file.hunks.iter().any(|h| !h.selected) {
+            git::stage_path(workdir, &file.path)?;
+        }
+    }
+    git::commit(workdir, msg2)?;
+
+    let hash2 = git::rev_parse(workdir, "HEAD")?;
+    let hash1 = git::rev_parse(workdir, "HEAD~1")?;
+    Ok((hash1, hash2))
+}
+
+/// Non-HEAD hunk-based split using edit-and-continue rebase.
+fn perform_non_head_split_by_hunks(
+    repo: &Repository,
+    workdir: &std::path::Path,
+    commit_oid: Oid,
+    selections: &[FileEntry],
+    msg1: Option<&str>,
+    msg2: &str,
+) -> Result<(String, String)> {
+    weave::start_edit_rebase(repo, workdir, commit_oid)?;
+
+    let (hash1, hash2) = match perform_head_split_by_hunks(workdir, selections, msg1, msg2) {
+        Ok(hashes) => hashes,
+        Err(e) => {
+            let _ = git::rebase_abort(workdir);
+            return Err(e);
+        }
+    };
+
+    git::continue_rebase_or_abort(workdir)?;
     Ok((hash1, hash2))
 }
 

--- a/src/tui/hunk_selector.rs
+++ b/src/tui/hunk_selector.rs
@@ -22,6 +22,8 @@ pub(crate) enum HunkOrigin {
     Staged,
     /// From `git diff` (unstaged working-tree change).
     Unstaged,
+    /// From a commit diff (`git diff <oid>^..<oid>`).
+    Commit,
 }
 
 /// A single hunk with a toggle state and origin.
@@ -339,6 +341,7 @@ impl HunkSelectorApp {
             let origin_label = match entry.origin {
                 HunkOrigin::Staged => " (staged)",
                 HunkOrigin::Unstaged => "",
+                HunkOrigin::Commit => "",
             };
             let header_text = format!(
                 "[{}] Hunk {}/{}{}",


### PR DESCRIPTION
feat: add commit-based hunk picker for split/fold -p workflows

Add collect_commit_hunks and run_commit_hunk_picker to staging.rs,
enabling the hunk picker TUI to display changes from a specific commit
(via git diff <oid>^..<oid>) rather than only working tree changes.
This is the building block for split -p, fold -p <c1> <c2>, and
fold -p <c> zz.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---

feat: implement split -p for hunk-level commit splitting

Add -p/--patch flag to the split command. When specified, the commit
hunk picker TUI is shown (all hunks unselected by default); selected
hunks go into the first commit, deselected hunks into the second.
Supports both HEAD and non-HEAD commits via the existing
edit-and-continue rebase path.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

feat: implement fold -p <c1> <c2> and fold -p <c> zz

Extend fold -p to support two new commit-based hunk picker workflows:

- fold -p <c1> <c2>: show hunks from c1, move selected ones into c2
  (requires c1 newer than c2; two-phase edit+continue rebase)
- fold -p <c> zz: show hunks from c, uncommit selected ones to
  working tree (HEAD and non-HEAD paths)

The existing fold -p [files] <commit> working-tree workflow is unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

fix: fold -p <commit> was folding whole file instead of selected hunks

`fold_files_into_commit` called `git stage_files` unconditionally, which
re-staged entire working-tree files and overwrote the precise hunk-level
staging that `apply_selections` had already set up.

Added `skip_staging: bool` parameter: when `true` (patch mode and
pre-staged mode) the `git add` step is skipped so only the caller's
staged hunks are folded in. The existing working-tree fold path passes
`false` and is unaffected.

Adds two regression tests covering the HEAD and non-HEAD cases.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>