### PR TITLE
Simplification

### DIFF
--- a/src/absorb.rs
+++ b/src/absorb.rs
@@ -101,6 +101,11 @@ fn build_plan(
     weave_graph: &Weave,
 ) -> Result<AbsorbPlan> {
     let in_scope: HashMap<Oid, &CommitInfo> = info.commits.iter().map(|c| (c.oid, c)).collect();
+    let commit_to_branch: HashMap<Oid, String> = weave_graph
+        .branch_sections
+        .iter()
+        .flat_map(|s| s.commits.iter().map(move |c| (c.oid, s.label.clone())))
+        .collect();
 
     let mut whole_file_assigned: Vec<(String, Oid)> = Vec::new();
     let mut hunk_assigned: Vec<(String, Oid, Vec<DiffHunk>)> = Vec::new();
@@ -110,7 +115,7 @@ fn build_plan(
     for file in changed_files {
         match analyze_file(repo, workdir, file, &in_scope)? {
             FileAnalysis::Assigned { commit_oid } => {
-                print_assignment(file, commit_oid, &in_scope, weave_graph);
+                print_assignment(file, commit_oid, &in_scope, &commit_to_branch);
                 whole_file_assigned.push((file.clone(), commit_oid));
                 any_assigned = true;
             }
@@ -128,7 +133,7 @@ fn build_plan(
                                 total,
                                 commit_oid,
                                 &in_scope,
-                                weave_graph,
+                                &commit_to_branch,
                             );
                             per_commit.entry(commit_oid).or_default().push(hunk);
                         }
@@ -198,7 +203,6 @@ fn apply_plan(repo: &Repository, workdir: &Path, git_dir: &Path, plan: AbsorbPla
     let saved_head = repo::head_oid(repo)?.to_string();
     let saved_refs = repo::snapshot_branch_refs(repo)?;
 
-    // Group assignments by target commit.
     let mut groups: HashMap<Oid, Vec<String>> = HashMap::new();
     for (file, oid) in &plan.whole_file_assigned {
         groups.entry(*oid).or_default().push(file.clone());
@@ -208,7 +212,7 @@ fn apply_plan(repo: &Repository, workdir: &Path, git_dir: &Path, plan: AbsorbPla
         hunk_groups.entry(oid).or_default().push((path, hunks));
     }
 
-    // Save staged files that are NOT being absorbed so they don't leak into fixup commits.
+    // Keep non-absorbed staged changes from leaking into fixup commits.
     let absorbed_files: HashSet<&str> = groups
         .values()
         .flatten()
@@ -317,19 +321,7 @@ fn create_fixup_commits(
             rollback_pre_rebase(workdir, pre_rebase);
             return Err(e);
         }
-        let subject = repo
-            .find_commit(*target_oid)
-            .ok()
-            .map(|c| repo::commit_subject(&c))
-            .unwrap_or_else(|| target_oid.to_string());
-        let msg = format!("fixup! {}", subject);
-        if let Err(e) = git::commit(workdir, &msg) {
-            rollback_pre_rebase(workdir, pre_rebase);
-            return Err(e);
-        }
-        let fixup_hash = git::rev_parse(workdir, "HEAD")?;
-        let fixup_oid = git2::Oid::from_str(&fixup_hash)?;
-        fixup_pairs.push((fixup_oid, *target_oid));
+        commit_fixup(repo, workdir, target_oid, pre_rebase, &mut fixup_pairs)?;
     }
 
     for (target_oid, file_hunks) in hunk_groups {
@@ -341,22 +333,34 @@ fn create_fixup_commits(
             rollback_pre_rebase(workdir, pre_rebase);
             return Err(e);
         }
-        let subject = repo
-            .find_commit(*target_oid)
-            .ok()
-            .map(|c| repo::commit_subject(&c))
-            .unwrap_or_else(|| target_oid.to_string());
-        let msg = format!("fixup! {}", subject);
-        if let Err(e) = git::commit(workdir, &msg) {
-            rollback_pre_rebase(workdir, pre_rebase);
-            return Err(e);
-        }
-        let fixup_hash = git::rev_parse(workdir, "HEAD")?;
-        let fixup_oid = git2::Oid::from_str(&fixup_hash)?;
-        fixup_pairs.push((fixup_oid, *target_oid));
+        commit_fixup(repo, workdir, target_oid, pre_rebase, &mut fixup_pairs)?;
     }
 
     Ok(fixup_pairs)
+}
+
+/// Commit a fixup for `target_oid` (staging already done by the caller) and record the pair.
+fn commit_fixup(
+    repo: &Repository,
+    workdir: &Path,
+    target_oid: &Oid,
+    pre_rebase: &PreRebaseState<'_>,
+    fixup_pairs: &mut Vec<(Oid, Oid)>,
+) -> Result<()> {
+    let subject = repo
+        .find_commit(*target_oid)
+        .ok()
+        .map(|c| repo::commit_subject(&c))
+        .unwrap_or_else(|| target_oid.to_string());
+    let msg = format!("fixup! {}", subject);
+    if let Err(e) = git::commit(workdir, &msg) {
+        rollback_pre_rebase(workdir, pre_rebase);
+        return Err(e);
+    }
+    let fixup_hash = git::rev_parse(workdir, "HEAD")?;
+    let fixup_oid = git2::Oid::from_str(&fixup_hash)?;
+    fixup_pairs.push((fixup_oid, *target_oid));
+    Ok(())
 }
 
 /// Save diffs for skipped files and restore their working-tree state before the rebase.
@@ -365,11 +369,10 @@ fn save_skipped_patch(workdir: &Path, skipped_files: &[String]) -> Result<Option
         return Ok(None);
     }
     let refs: Vec<&str> = skipped_files.iter().map(|f| f.as_str()).collect();
-    let dirty = git::diff_head_name_only(workdir)?;
-    if dirty.trim().is_empty() {
+    let patch = git::diff_head_files(workdir, &refs)?;
+    if patch.trim().is_empty() {
         return Ok(None);
     }
-    let patch = git::diff_head_files(workdir, &refs)?;
     let _ = git::restore_files_to_head(workdir, &refs);
     Ok(Some(patch))
 }
@@ -439,15 +442,15 @@ fn post_absorb(
 fn commit_label(
     commit_oid: Oid,
     in_scope: &HashMap<Oid, &CommitInfo>,
-    weave_graph: &Weave,
+    commit_to_branch: &HashMap<Oid, String>,
 ) -> String {
-    let oid_str = commit_oid.to_string();
-    let short = git::short_hash(&oid_str);
-    let message = in_scope
+    let info = in_scope.get(&commit_oid);
+    let short = info
+        .map(|c| c.short_id.as_str())
+        .unwrap_or_else(|| "???????");
+    let message = info.map(|c| c.message.as_str()).unwrap_or("");
+    let branch_info = commit_to_branch
         .get(&commit_oid)
-        .map(|c| c.message.as_str())
-        .unwrap_or("");
-    let branch_info = find_branch_for_commit(weave_graph, commit_oid)
         .map(|b| format!(" ({})", b))
         .unwrap_or_default();
     format!("{} \"{}\"{}", short, message, branch_info)
@@ -458,12 +461,12 @@ fn print_assignment(
     file: &str,
     commit_oid: Oid,
     in_scope: &HashMap<Oid, &CommitInfo>,
-    weave_graph: &Weave,
+    commit_to_branch: &HashMap<Oid, String>,
 ) {
     println!(
         "  {} -> {}",
         file,
-        commit_label(commit_oid, in_scope, weave_graph)
+        commit_label(commit_oid, in_scope, commit_to_branch)
     );
 }
 
@@ -474,14 +477,14 @@ fn print_hunk_assignment(
     total: usize,
     commit_oid: Oid,
     in_scope: &HashMap<Oid, &CommitInfo>,
-    weave_graph: &Weave,
+    commit_to_branch: &HashMap<Oid, String>,
 ) {
     println!(
         "  {} [hunk {}/{}] -> {}",
         file,
         hunk_num,
         total,
-        commit_label(commit_oid, in_scope, weave_graph)
+        commit_label(commit_oid, in_scope, commit_to_branch)
     );
 }
 
@@ -651,18 +654,6 @@ fn analyze_hunk(
     }
 
     HunkAnalysis::Assigned { commit_oid }
-}
-
-/// Find the branch name that contains a given commit OID in the Weave graph.
-fn find_branch_for_commit(weave: &Weave, oid: Oid) -> Option<String> {
-    for section in &weave.branch_sections {
-        for commit in &section.commits {
-            if commit.oid == oid {
-                return Some(section.label.clone());
-            }
-        }
-    }
-    None
 }
 
 #[cfg(test)]

--- a/src/absorb.rs
+++ b/src/absorb.rs
@@ -508,18 +508,10 @@ fn get_changed_files(
     } else {
         let mut result = Vec::new();
         for arg in user_files {
-            let path = resolve_file_arg(repo, arg)?;
+            let path = repo::resolve_file_arg(repo, arg)?;
             result.push(path);
         }
         Ok(result)
-    }
-}
-
-/// Resolve a user argument to a file path using the centralized resolver.
-fn resolve_file_arg(repo: &Repository, arg: &str) -> Result<String> {
-    match repo::resolve_arg(repo, arg, &[repo::TargetKind::File])? {
-        repo::Target::File(path) => Ok(path),
-        _ => unreachable!(),
     }
 }
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
-use git2::{Repository, StatusOptions};
+use git2::Repository;
 use serde::{Deserialize, Serialize};
 
 use crate::core::graph;
 use crate::core::msg;
-use crate::core::repo::{self, Target};
+use crate::core::repo;
 use crate::core::staging;
 use crate::core::transaction::{self, LoomState, Rollback};
 use crate::core::weave::{self, RebaseOutcome, Weave};
@@ -39,20 +39,27 @@ pub fn run(
          Use `git commit` directly on feature branches",
     )?;
 
-    // Step 1: Stage files (saving aside any pre-existing staged files not in
-    // the target list so they don't accidentally end up in this commit).
+    // Stage files, saving aside any pre-existing staged files not in the
+    // target list so they don't accidentally end up in this commit.
     let saved_staged = if patch {
         resolve_staging_patch(&repo, &workdir, &files, theme)?
     } else {
         resolve_staging(&repo, &workdir, &files)?
     };
 
-    // Step 2: Verify index has changes — restore saved staged on failure so
-    // pre-existing staged work is not lost.
-    if let Err(e) = verify_has_staged_changes(&repo) {
+    // Verify index has changes — restore saved staged on failure so pre-existing staged work is not lost.
+    if let Err(e) = repo::verify_has_staged_changes(&repo) {
         git::restore_staged_patch(&workdir, &saved_staged)?;
         return Err(e);
     }
+
+    let do_commit = || {
+        if let Some(msg) = &message {
+            git::commit(&workdir, msg)
+        } else {
+            git::commit_with_editor(&workdir)
+        }
+    };
 
     // Loose commit: when no -b flag and local branch name matches the
     // upstream's local counterpart (e.g. "main" tracking "origin/main"),
@@ -60,11 +67,7 @@ pub fn run(
     // branch. This works regardless of whether local commits or woven
     // branches already exist.
     if branch.is_none() && info.branch_name == repo::upstream_local_branch(&info.upstream.label) {
-        let result = if let Some(msg) = &message {
-            git::commit(&workdir, msg)
-        } else {
-            git::commit_with_editor(&workdir)
-        };
+        let result = do_commit();
         git::restore_staged_patch(&workdir, &saved_staged)?;
         result?;
         let new_head = repo::head_oid(&repo)?;
@@ -75,38 +78,24 @@ pub fn run(
         return Ok(());
     }
 
-    // Step 3: Save HEAD for rollback
     let saved_head = repo::head_oid(&repo)?.to_string();
 
-    // Step 4: Resolve branch target (may create a new branch at merge-base)
-    // Snapshot existing branch names so we can detect newly-created branches.
-    // Only delete newly-created branches on rollback (not pre-existing empty ones).
-    let branches_before: Vec<String> = repo
-        .branches(Some(git2::BranchType::Local))?
-        .filter_map(|b| b.ok())
-        .filter_map(|(b, _)| b.name().ok().flatten().map(String::from))
-        .collect();
-    let branch_name = resolve_branch_target(&repo, &info, &workdir, branch.as_deref())?;
-    let branch_is_new = !branches_before.contains(&branch_name);
+    // Resolve branch target (may create a new branch at merge-base).
+    // Returns whether the branch was newly created — only newly-created
+    // branches are deleted on rollback (not pre-existing empty ones).
+    let (branch_name, branch_is_new) =
+        resolve_branch_target(&repo, &info, &workdir, branch.as_deref())?;
 
-    // Check if the branch is at the merge-base (no commits of its own).
-    // Empty branches need to have a branch section and merge entry created
-    // in the Weave before moving the commit there.
+    // Empty branches (pointing at merge-base) need a branch section and
+    // merge entry created in the Weave before moving the commit there.
     let branch_is_empty =
         is_branch_at_merge_base(&repo, &branch_name, info.upstream.merge_base_oid)?;
 
-    // Step 5: Create commit at HEAD
-    let commit_result = if let Some(msg) = &message {
-        git::commit(&workdir, msg)
-    } else {
-        git::commit_with_editor(&workdir)
-    };
-    if let Err(e) = commit_result {
+    if let Err(e) = do_commit() {
         git::restore_staged_patch(&workdir, &saved_staged)?;
         return Err(e);
     }
 
-    // Step 6: Move commit to branch via Weave
     let head_oid = repo::head_oid(&repo)?;
 
     let mut graph = Weave::from_repo_with_info(&repo, &info)?;
@@ -200,13 +189,9 @@ fn resolve_staging_patch(
 ) -> Result<String> {
     // Save aside other staged files when specific files are targeted.
     let saved_staged = if !files.is_empty() && !files.iter().any(|f| f == "zz") {
-        let mut resolved_paths = Vec::new();
-        for arg in files {
-            let path = resolve_file_arg(repo, arg)?;
-            resolved_paths.push(path);
-        }
+        let resolved_paths = resolve_file_args(repo, files)?;
         let path_refs: Vec<&str> = resolved_paths.iter().map(|s| s.as_str()).collect();
-        save_and_unstage_other_staged(repo, workdir, &path_refs)?
+        staging::save_and_unstage_other_staged(repo, workdir, &path_refs)?
     } else {
         String::new()
     };
@@ -241,85 +226,31 @@ fn resolve_staging(
         return Ok(String::new());
     }
 
-    let mut resolved_paths = Vec::new();
-    for arg in files {
-        let path = resolve_file_arg(repo, arg)?;
-        resolved_paths.push(path);
-    }
-
+    let resolved_paths = resolve_file_args(repo, files)?;
     let path_refs: Vec<&str> = resolved_paths.iter().map(|s| s.as_str()).collect();
-
-    // Save and unstage any pre-existing staged files not in our target list.
-    let saved_staged = save_and_unstage_other_staged(repo, workdir, &path_refs)?;
-
+    let saved_staged = staging::save_and_unstage_other_staged(repo, workdir, &path_refs)?;
     git::stage_files(workdir, &path_refs)?;
-
     Ok(saved_staged)
 }
 
-/// Save the staged diff for files that are staged but NOT in `target_files`,
-/// then unstage them so they don't leak into the upcoming commit.
-///
-/// Returns the patch as a string (may be empty if nothing to save).
-fn save_and_unstage_other_staged(
-    repo: &Repository,
-    workdir: &std::path::Path,
-    target_files: &[&str],
-) -> Result<String> {
-    let staged = repo::get_staged_files(repo)?;
-    let other: Vec<&str> = staged
+/// Resolve a slice of user file arguments to repo-relative paths.
+fn resolve_file_args(repo: &Repository, files: &[String]) -> Result<Vec<String>> {
+    files
         .iter()
-        .filter(|f| !target_files.contains(&f.as_str()))
-        .map(|s| s.as_str())
-        .collect();
-
-    if other.is_empty() {
-        return Ok(String::new());
-    }
-
-    let patch = git::diff_cached_files(workdir, &other)?;
-    git::unstage_files(workdir, &other)?;
-    Ok(patch)
-}
-
-/// Resolve a file argument using the centralized resolver.
-fn resolve_file_arg(repo: &Repository, arg: &str) -> Result<String> {
-    match repo::resolve_arg(repo, arg, &[repo::TargetKind::File])? {
-        Target::File(path) => Ok(path),
-        _ => unreachable!(),
-    }
-}
-
-/// Verify that the index has staged changes.
-pub fn verify_has_staged_changes(repo: &Repository) -> Result<()> {
-    let mut opts = StatusOptions::new();
-    opts.include_untracked(false);
-
-    let statuses = repo.statuses(Some(&mut opts))?;
-
-    let has_staged = statuses.iter().any(|entry| {
-        let status = entry.status();
-        status.is_index_new()
-            || status.is_index_modified()
-            || status.is_index_deleted()
-            || status.is_index_renamed()
-            || status.is_index_typechange()
-    });
-
-    if !has_staged {
-        bail!("Nothing to commit");
-    }
-
-    Ok(())
+        .map(|arg| repo::resolve_file_arg(repo, arg))
+        .collect()
 }
 
 /// Resolve the target branch: explicit name/shortID, or interactive picker.
+///
+/// Returns `(branch_name, is_new)` — `is_new` is true when the branch was
+/// created by this call (only newly-created branches are deleted on rollback).
 fn resolve_branch_target(
     repo: &Repository,
     info: &repo::RepoInfo,
     workdir: &std::path::Path,
     branch: Option<&str>,
-) -> Result<String> {
+) -> Result<(String, bool)> {
     match branch {
         Some(b) => resolve_explicit_branch(repo, info, workdir, b),
         None => pick_branch(repo, info, workdir),
@@ -336,12 +267,12 @@ fn resolve_explicit_branch(
     info: &repo::RepoInfo,
     workdir: &std::path::Path,
     branch: &str,
-) -> Result<String> {
+) -> Result<(String, bool)> {
     match repo::resolve_arg(repo, branch, &[repo::TargetKind::Branch]) {
         Ok(target) => {
             let name = target.expect_branch()?;
             if info.branches.iter().any(|b| b.name == name) {
-                Ok(name)
+                Ok((name, false))
             } else {
                 bail!("Branch '{}' is not woven into the integration branch", name)
             }
@@ -362,7 +293,7 @@ fn resolve_explicit_branch(
             }
 
             create_branch_at_merge_base(workdir, &name, info.upstream.merge_base_oid)?;
-            Ok(name)
+            Ok((name, true))
         }
     }
 }
@@ -372,7 +303,7 @@ fn pick_branch(
     repo: &Repository,
     info: &repo::RepoInfo,
     workdir: &std::path::Path,
-) -> Result<String> {
+) -> Result<(String, bool)> {
     let branch_names: Vec<String> = info.branches.iter().map(|b| b.name.clone()).collect();
 
     let not_empty = |s: &str| {
@@ -396,9 +327,10 @@ fn pick_branch(
         git::branch_validate_name(&name)?;
         repo::ensure_branch_not_exists(repo, &name)?;
         create_branch_at_merge_base(workdir, &name, info.upstream.merge_base_oid)?;
+        return Ok((name, true));
     }
 
-    Ok(name)
+    Ok((name, false))
 }
 
 /// Check if a branch points to the merge-base commit (i.e., has no commits of its own).

--- a/src/commit_test.rs
+++ b/src/commit_test.rs
@@ -599,7 +599,7 @@ fn commit_accepts_staged_rename_only() {
         .unwrap();
 
     // verify_has_staged_changes should accept a rename-only index
-    let result = super::verify_has_staged_changes(&test_repo.repo);
+    let result = crate::core::repo::verify_has_staged_changes(&test_repo.repo);
     assert!(
         result.is_ok(),
         "staged rename should be accepted, got: {:?}",

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -622,6 +622,22 @@ pub fn get_staged_files(repo: &Repository) -> Result<Vec<String>> {
     Ok(paths)
 }
 
+/// Resolve a user argument to a file path.
+pub fn resolve_file_arg(repo: &Repository, arg: &str) -> Result<String> {
+    match resolve_arg(repo, arg, &[TargetKind::File])? {
+        Target::File(path) => Ok(path),
+        _ => unreachable!(),
+    }
+}
+
+/// Check that the index has at least one staged change; bail if not.
+pub fn verify_has_staged_changes(repo: &Repository) -> Result<()> {
+    if get_staged_files(repo)?.is_empty() {
+        anyhow::bail!("Nothing to commit");
+    }
+    Ok(())
+}
+
 /// Count the number of commits reachable from `from` but not from `hide`.
 fn count_commits(repo: &Repository, from: git2::Oid, hide: git2::Oid) -> Result<usize> {
     if from == hide {

--- a/src/core/staging.rs
+++ b/src/core/staging.rs
@@ -448,6 +448,29 @@ pub(crate) fn save_and_unstage_staged(repo: &Repository, workdir: &Path) -> Resu
     Ok(patch)
 }
 
+/// Save the staged diff for files that are staged but NOT in `target_files`,
+/// then unstage them so they don't leak into the upcoming commit.
+///
+/// Returns the patch as a string (may be empty if nothing to save).
+pub(crate) fn save_and_unstage_other_staged(
+    repo: &Repository,
+    workdir: &Path,
+    target_files: &[&str],
+) -> Result<String> {
+    let staged = repo::get_staged_files(repo)?;
+    let other: Vec<&str> = staged
+        .iter()
+        .filter(|f| !target_files.contains(&f.as_str()))
+        .map(|s| s.as_str())
+        .collect();
+    if other.is_empty() {
+        return Ok(String::new());
+    }
+    let patch = git::diff_cached_files(workdir, &other)?;
+    git::unstage_files(workdir, &other)?;
+    Ok(patch)
+}
+
 fn hunk_sort_key(hunk: &diff::DiffHunk) -> usize {
     let first_line = hunk.text.lines().next().unwrap_or("");
     parse_hunk_start(first_line).unwrap_or(0)

--- a/src/core/staging.rs
+++ b/src/core/staging.rs
@@ -432,6 +432,22 @@ pub(crate) fn collect_commit_hunks(
     Ok(entries)
 }
 
+/// Save and unstage all currently staged changes, returning a patch to restore them later.
+///
+/// Returns an empty string if nothing is staged. Callers must call
+/// `git::restore_staged_patch` with the returned patch when the operation
+/// completes (or is rolled back), so pre-existing staged work is never lost.
+pub(crate) fn save_and_unstage_staged(repo: &Repository, workdir: &Path) -> Result<String> {
+    let staged = repo::get_staged_files(repo)?;
+    if staged.is_empty() {
+        return Ok(String::new());
+    }
+    let refs: Vec<&str> = staged.iter().map(|s| s.as_str()).collect();
+    let patch = git::diff_cached_files(workdir, &refs)?;
+    git::unstage_files(workdir, &refs)?;
+    Ok(patch)
+}
+
 fn hunk_sort_key(hunk: &diff::DiffHunk) -> usize {
     let first_line = hunk.text.lines().next().unwrap_or("");
     parse_hunk_start(first_line).unwrap_or(0)

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -12,6 +12,13 @@ use crate::core::transaction::{self, LoomState, Rollback};
 use crate::core::weave::{self, RebaseOutcome, Weave};
 use crate::git;
 
+fn confirm_or_bail(skip: bool, prompt: &str) -> Result<()> {
+    if !skip && !msg::confirm(prompt)? {
+        bail!("Cancelled");
+    }
+    Ok(())
+}
+
 #[derive(Serialize, Deserialize)]
 struct DropContext {
     commit_hash: String,
@@ -64,16 +71,12 @@ fn drop_file(repo: &Repository, path: &str, skip_confirm: bool) -> Result<()> {
             !statuses.is_empty()
         };
         if has_tracked {
-            if !skip_confirm && !msg::confirm(&format!("Discard all changes in `{}`?", path))? {
-                bail!("Cancelled");
-            }
+            confirm_or_bail(skip_confirm, &format!("Discard all changes in `{}`?", path))?;
             git::run_git(workdir, &["restore", "--staged", "--worktree", path])?;
             git::run_git(workdir, &["clean", "-fd", "--", path])?;
             msg::success(&format!("Restored `{}`", path));
         } else {
-            if !skip_confirm && !msg::confirm(&format!("Delete `{}`?", path))? {
-                bail!("Cancelled");
-            }
+            confirm_or_bail(skip_confirm, &format!("Delete `{}`?", path))?;
             git::run_git(workdir, &["clean", "-fd", "--", path])?;
             msg::success(&format!("Deleted `{}`", path));
         }
@@ -86,24 +89,18 @@ fn drop_file(repo: &Repository, path: &str, skip_confirm: bool) -> Result<()> {
 
     if status.is_wt_new() {
         // Untracked file — delete it
-        if !skip_confirm && !msg::confirm(&format!("Delete `{}`?", path))? {
-            bail!("Cancelled");
-        }
+        confirm_or_bail(skip_confirm, &format!("Delete `{}`?", path))?;
         std::fs::remove_file(workdir.join(path))
             .with_context(|| format!("Failed to delete '{}'", path))?;
         msg::success(&format!("Deleted `{}`", path));
     } else if status.is_index_new() {
         // Staged new file — remove from index and disk
-        if !skip_confirm && !msg::confirm(&format!("Delete `{}`?", path))? {
-            bail!("Cancelled");
-        }
+        confirm_or_bail(skip_confirm, &format!("Delete `{}`?", path))?;
         git::run_git(workdir, &["rm", "--force", path])?;
         msg::success(&format!("Deleted `{}`", path));
     } else {
         // Tracked file with modifications — restore it
-        if !skip_confirm && !msg::confirm(&format!("Discard changes to `{}`?", path))? {
-            bail!("Cancelled");
-        }
+        confirm_or_bail(skip_confirm, &format!("Discard changes to `{}`?", path))?;
         git::run_git(workdir, &["restore", "--staged", "--worktree", path])?;
         msg::success(&format!("Restored `{}`", path));
     }
@@ -123,9 +120,7 @@ fn drop_all(repo: &Repository, skip_confirm: bool) -> Result<()> {
         bail!("No local changes to discard");
     }
 
-    if !skip_confirm && !msg::confirm("Discard all local changes?")? {
-        bail!("Cancelled");
-    }
+    confirm_or_bail(skip_confirm, "Discard all local changes?")?;
 
     git::run_git(workdir, &["restore", "--staged", "--worktree", "."])?;
     git::run_git(workdir, &["clean", "-fd"])?;
@@ -165,22 +160,16 @@ fn drop_commit(repo: &Repository, commit_hash: &str, skip_confirm: bool) -> Resu
         }
     }
 
-    // Confirm with the user
     let short_hash = git::short_hash(commit_hash);
-    let summary = repo
-        .find_commit(commit_oid)?
-        .summary()
-        .unwrap_or("")
-        .to_string();
-    if !skip_confirm && !msg::confirm(&format!("Drop commit `{}` {}?", short_hash, summary))? {
-        bail!("Cancelled");
-    }
+    let summary = repo::commit_subject(&repo.find_commit(commit_oid)?);
+    confirm_or_bail(
+        skip_confirm,
+        &format!("Drop commit `{}` {}?", short_hash, summary),
+    )?;
 
-    // Build weave and drop the commit
     let mut graph = Weave::from_repo_with_info(repo, &info)?;
     graph.drop_commit(commit_oid);
 
-    // Save LoomState before the rebase so we can resume on conflict.
     let ctx = DropContext {
         commit_hash: commit_hash.to_string(),
     };
@@ -249,9 +238,10 @@ fn drop_branch_with_info(
 
     // Check if branch is at the merge-base with no owned commits
     if branch_info.tip_oid == merge_base_oid {
-        if !skip_confirm && !msg::confirm(&format!("Drop empty branch `{}`?", branch_name))? {
-            bail!("Cancelled");
-        }
+        confirm_or_bail(
+            skip_confirm,
+            &format!("Drop empty branch `{}`?", branch_name),
+        )?;
         git::branch_delete(workdir, branch_name)?;
         msg::success(&format!("Dropped branch `{}`", branch_name));
         return Ok(());
@@ -266,19 +256,15 @@ fn drop_branch_with_info(
         branch_name,
     )?;
     let commit_count = owned.len();
-    if !skip_confirm {
-        let prompt = if commit_count == 1 {
-            format!("Drop branch `{}` and its 1 commit?", branch_name)
-        } else {
-            format!(
-                "Drop branch `{}` and its {} commits?",
-                branch_name, commit_count
-            )
-        };
-        if !msg::confirm(&prompt)? {
-            bail!("Cancelled");
-        }
-    }
+    let prompt = if commit_count == 1 {
+        format!("Drop branch `{}` and its 1 commit?", branch_name)
+    } else {
+        format!(
+            "Drop branch `{}` and its {} commits?",
+            branch_name, commit_count
+        )
+    };
+    confirm_or_bail(skip_confirm, &prompt)?;
 
     // Check if another branch shares the same tip (co-located branches)
     let colocated_branch = info
@@ -290,7 +276,6 @@ fn drop_branch_with_info(
     let is_woven = branch_info.tip_oid != head_oid
         && !is_on_first_parent_line(repo, head_oid, merge_base_oid, branch_info.tip_oid)?;
 
-    // Build weave and apply the appropriate mutation
     let mut graph = Weave::from_repo_with_info(repo, info)?;
 
     if is_woven {

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -3,7 +3,6 @@ use git2::{Repository, StatusOptions};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-use crate::commit;
 use crate::core::diff;
 use crate::core::graph;
 use crate::core::msg;
@@ -289,7 +288,7 @@ fn run_patch_fold(repo: &Repository, args: &[String], theme: &graph::Theme) -> R
     }
 
     // Fold whatever is now staged into the target commit.
-    commit::verify_has_staged_changes(repo)?;
+    repo::verify_has_staged_changes(repo)?;
     let staged = repo::get_staged_files(repo)?;
     fold_files_into_commit(repo, &staged, &commit_hash, true)
 }
@@ -574,7 +573,7 @@ fn run_staged(repo: &Repository, target_arg: &str) -> Result<()> {
         _ => unreachable!(),
     };
 
-    commit::verify_has_staged_changes(repo)?;
+    repo::verify_has_staged_changes(repo)?;
 
     let staged = repo::get_staged_files(repo)?;
     fold_files_into_commit(repo, &staged, &commit_hash, true)

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -273,23 +273,22 @@ fn run_patch_fold(repo: &Repository, args: &[String], theme: &graph::Theme) -> R
         }
     }
 
-    // Resolve target commit.
     let resolved = repo::resolve_arg(repo, target_arg, &[TargetKind::Commit])?;
     let commit_hash = match resolved {
         Target::Commit(hash) => hash,
         _ => unreachable!(),
     };
 
-    // Open the hunk picker (filtered to source_args if provided, else all changes).
     let confirmed = staging::run_hunk_picker(repo, workdir, source_args, theme)?;
     if !confirmed {
         msg::error("Fold cancelled");
         return Ok(());
     }
 
-    // Fold whatever is now staged into the target commit.
-    repo::verify_has_staged_changes(repo)?;
     let staged = repo::get_staged_files(repo)?;
+    if staged.is_empty() {
+        bail!("Nothing to commit");
+    }
     fold_files_into_commit(repo, &staged, &commit_hash, true)
 }
 
@@ -420,7 +419,7 @@ fn run_patch_fold_commit_to_commit(
     let phase2_target_oid = git2::Oid::from_str(&phase2_target_hash)?;
 
     // Re-open repo after phase 1 rebase (OIDs changed)
-    let repo2 = Repository::discover(workdir)?;
+    let repo2 = Repository::open(workdir)?;
     let mut graph2 = Weave::from_repo(&repo2)?;
     graph2.edit_commit(phase2_target_oid);
     let todo2 = graph2.to_todo();
@@ -573,9 +572,10 @@ fn run_staged(repo: &Repository, target_arg: &str) -> Result<()> {
         _ => unreachable!(),
     };
 
-    repo::verify_has_staged_changes(repo)?;
-
     let staged = repo::get_staged_files(repo)?;
+    if staged.is_empty() {
+        bail!("Nothing to commit");
+    }
     fold_files_into_commit(repo, &staged, &commit_hash, true)
 }
 
@@ -761,7 +761,6 @@ fn fold_files_into_commit(
 ) -> Result<()> {
     let workdir = repo::require_workdir(repo, COMMAND)?;
 
-    // Validate all files have changes
     if !skip_staging {
         for file in files {
             if !repo::path_has_changes(repo, file)? {
@@ -778,19 +777,7 @@ fn fold_files_into_commit(
 
     // Save and unstage any pre-existing staged files not in our target list,
     // so they don't accidentally end up in this commit/amend.
-    let staged = repo::get_staged_files(repo)?;
-    let other_staged: Vec<&str> = staged
-        .iter()
-        .filter(|f| !file_refs.contains(&f.as_str()))
-        .map(|s| s.as_str())
-        .collect();
-    let saved_staged = if other_staged.is_empty() {
-        String::new()
-    } else {
-        let patch = git::diff_cached_files(workdir, &other_staged)?;
-        git::unstage_files(workdir, &other_staged)?;
-        patch
-    };
+    let saved_staged = staging::save_and_unstage_other_staged(repo, workdir, &file_refs)?;
 
     let new_hash;
 
@@ -831,7 +818,7 @@ fn fold_files_into_commit(
         let fixup_oid = git2::Oid::from_str(&fixup_hash)?;
 
         // Re-open repo after creating the fixup commit (OIDs changed)
-        let repo2 = Repository::discover(workdir)?;
+        let repo2 = Repository::open(workdir)?;
         let mut graph = Weave::from_repo(&repo2)?;
         graph.fixup_commit(fixup_oid, target_oid)?;
 
@@ -841,7 +828,6 @@ fn fold_files_into_commit(
         git::branch_force_create(workdir, TRACK_BRANCH, commit_hash)?;
         graph.track_commit(target_oid, TRACK_BRANCH);
 
-        // Save LoomState before the rebase.
         let git_dir = repo.path().to_path_buf();
         let fold_ctx = serde_json::to_value(FoldVariant::FilesIntoCommit {
             original_commit_hash: commit_hash.to_string(),
@@ -908,7 +894,6 @@ fn fold_commit_into_commit(repo: &Repository, source_hash: &str, target_hash: &s
     git::branch_force_create(workdir, TRACK_BRANCH, target_hash)?;
     graph.track_commit(target_oid, TRACK_BRANCH);
 
-    // Save LoomState before the rebase.
     let git_dir = repo.path().to_path_buf();
     let fold_ctx = serde_json::to_value(FoldVariant::CommitIntoCommit {
         source_hash: source_hash.to_string(),
@@ -1198,7 +1183,7 @@ fn fold_commit_file_to_commit(
         let phase2_target_oid = git2::Oid::from_str(&phase2_target_hash)?;
 
         // Re-open repo after phase 1 rebase (OIDs changed)
-        let repo2 = Repository::discover(workdir)?;
+        let repo2 = Repository::open(workdir)?;
         let mut graph2 = Weave::from_repo(&repo2)?;
         graph2.edit_commit(phase2_target_oid);
 
@@ -1303,7 +1288,6 @@ fn fold_commit_to_unstaged(repo: &Repository, commit_hash: &str) -> Result<()> {
         let mut graph = Weave::from_repo(repo)?;
         graph.drop_commit(target_oid);
 
-        // Save LoomState before the rebase.
         let git_dir = repo.path().to_path_buf();
         let fold_ctx = serde_json::to_value(FoldVariant::CommitToUnstaged {
             commit_hash: commit_hash.to_string(),

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -38,6 +38,7 @@ enum FoldVariant {
 
 /// Temporary branch used to track a commit's new OID through a rebase.
 const TRACK_BRANCH: &str = "_loom-track";
+const COMMAND: &str = "fold";
 
 /// Fold source(s) into a target.
 ///
@@ -148,7 +149,7 @@ fn run_create(repo: &Repository, args: &[String]) -> Result<()> {
     }
 
     let (source_arg, branch_name) = (&args[0], &args[1]);
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
 
     // Resolve source — must be a commit
     let source = repo::resolve_arg(repo, source_arg, &[TargetKind::Commit])?;
@@ -227,7 +228,7 @@ fn create_branch_and_move(
 /// - `fold -p <commit1> <commit2>` — pick hunks from commit1 to move into commit2
 /// - `fold -p <commit> zz` — pick hunks from commit to uncommit to working tree
 fn run_patch_fold(repo: &Repository, args: &[String], theme: &graph::Theme) -> Result<()> {
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
 
     let (target_arg, source_args) = args.split_last().expect("args is non-empty");
 
@@ -313,20 +314,29 @@ fn build_selected_patch(selections: &[FileEntry]) -> String {
     patch
 }
 
-/// At a rebase edit pause: reverse-apply patch, stage affected files, amend.
-fn reverse_apply_and_amend(workdir: &Path, selections: &[FileEntry], patch: &str) -> Result<()> {
-    git::apply_patch_reverse(workdir, patch)?;
-    for file in selections {
-        if file.hunks.iter().any(|h| h.selected) {
-            git::stage_path(workdir, &file.path)?;
-        }
+/// At a rebase edit pause: apply (or reverse-apply) a single-file patch, stage the path, amend.
+fn apply_and_amend_path(workdir: &Path, patch: &str, path: &str, reverse: bool) -> Result<()> {
+    if reverse {
+        git::apply_patch_reverse(workdir, patch)?;
+    } else {
+        git::apply_patch(workdir, patch)?;
     }
+    git::stage_path(workdir, path)?;
     git::commit_amend_no_edit(workdir)
 }
 
-/// At a rebase edit pause: apply patch, stage affected files, amend.
-fn apply_and_amend(workdir: &Path, selections: &[FileEntry], patch: &str) -> Result<()> {
-    git::apply_patch(workdir, patch)?;
+/// At a rebase edit pause: apply (or reverse-apply) patch, stage affected files, amend.
+fn apply_and_amend(
+    workdir: &Path,
+    selections: &[FileEntry],
+    patch: &str,
+    reverse: bool,
+) -> Result<()> {
+    if reverse {
+        git::apply_patch_reverse(workdir, patch)?;
+    } else {
+        git::apply_patch(workdir, patch)?;
+    }
     for file in selections {
         if file.hunks.iter().any(|h| h.selected) {
             git::stage_path(workdir, &file.path)?;
@@ -376,7 +386,7 @@ fn run_patch_fold_commit_to_commit(
 
     // Save and unstage any pre-existing staged changes so they don't accidentally
     // get included in the amend operations below.
-    let saved_staged = save_and_unstage_all_staged(repo, workdir)?;
+    let saved_staged = staging::save_and_unstage_staged(repo, workdir)?;
 
     // Phase 1: edit source, remove selected hunks.
     let mut graph = Weave::from_repo(repo)?;
@@ -390,7 +400,7 @@ fn run_patch_fold_commit_to_commit(
         return Err(e);
     }
 
-    if let Err(e) = reverse_apply_and_amend(workdir, &selections, &selected_patch) {
+    if let Err(e) = apply_and_amend(workdir, &selections, &selected_patch, true) {
         let _ = git::rebase_abort(workdir);
         let _ = git::branch_delete(workdir, TRACK_BRANCH);
         let _ = git::restore_staged_patch(workdir, &saved_staged);
@@ -410,7 +420,8 @@ fn run_patch_fold_commit_to_commit(
     let _ = git::branch_delete(workdir, TRACK_BRANCH);
     let phase2_target_oid = git2::Oid::from_str(&phase2_target_hash)?;
 
-    let repo2 = git2::Repository::discover(workdir)?;
+    // Re-open repo after phase 1 rebase (OIDs changed)
+    let repo2 = Repository::discover(workdir)?;
     let mut graph2 = Weave::from_repo(&repo2)?;
     graph2.edit_commit(phase2_target_oid);
     let todo2 = graph2.to_todo();
@@ -429,7 +440,7 @@ fn run_patch_fold_commit_to_commit(
         return Err(e);
     }
 
-    if let Err(e) = apply_and_amend(workdir, &selections, &selected_patch) {
+    if let Err(e) = apply_and_amend(workdir, &selections, &selected_patch, false) {
         let _ = git::rebase_abort(workdir);
         rollback(&saved_head, &saved_refs);
         let _ = git::restore_staged_patch(workdir, &saved_staged);
@@ -487,7 +498,7 @@ fn run_patch_fold_commit_to_unstaged(
 
     // Save and unstage any pre-existing staged changes so they don't accidentally
     // get included in the amend operation below.
-    let saved_staged = save_and_unstage_all_staged(repo, workdir)?;
+    let saved_staged = staging::save_and_unstage_staged(repo, workdir)?;
 
     let new_hash;
 
@@ -521,7 +532,7 @@ fn run_patch_fold_commit_to_unstaged(
             return Err(e);
         }
 
-        if let Err(e) = reverse_apply_and_amend(workdir, &selections, &selected_patch) {
+        if let Err(e) = apply_and_amend(workdir, &selections, &selected_patch, true) {
             let _ = git::rebase_abort(workdir);
             let _ = git::restore_staged_patch(workdir, &saved_staged);
             return Err(e);
@@ -614,7 +625,6 @@ fn classify(sources: &[Target], target: &Target) -> Result<FoldOp> {
         bail!("Target must be a commit, branch, or unstaged (zz), not a commit file");
     }
 
-    // Classify source types
     let has_files = sources.iter().any(|s| matches!(s, Target::File(_)));
     let has_commits = sources.iter().any(|s| matches!(s, Target::Commit(_)));
     let has_commit_files = sources
@@ -726,26 +736,10 @@ fn classify(sources: &[Target], target: &Target) -> Result<FoldOp> {
     }
 }
 
-/// Save and unstage all currently staged changes, returning a patch to restore them later.
-///
-/// Returns an empty string if nothing is staged. Callers must call
-/// `git::restore_staged_patch` with the returned patch when the operation
-/// completes (or is rolled back), so pre-existing staged work is never lost.
-fn save_and_unstage_all_staged(repo: &Repository, workdir: &Path) -> Result<String> {
-    let staged = repo::get_staged_files(repo)?;
-    if staged.is_empty() {
-        return Ok(String::new());
-    }
-    let refs: Vec<&str> = staged.iter().map(|s| s.as_str()).collect();
-    let patch = git::diff_cached_files(workdir, &refs)?;
-    git::unstage_files(workdir, &refs)?;
-    Ok(patch)
-}
-
 /// Collect all file paths with staged or unstaged changes.
 fn collect_changed_files(repo: &Repository) -> Result<Vec<String>> {
     let mut opts = StatusOptions::new();
-    opts.include_untracked(true).recurse_untracked_dirs(false);
+    opts.include_untracked(true).recurse_untracked_dirs(true);
     let statuses = repo.statuses(Some(&mut opts))?;
     let mut paths = Vec::new();
     for entry in statuses.iter() {
@@ -766,7 +760,7 @@ fn fold_files_into_commit(
     commit_hash: &str,
     skip_staging: bool,
 ) -> Result<()> {
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
 
     // Validate all files have changes
     if !skip_staging {
@@ -802,7 +796,6 @@ fn fold_files_into_commit(
     let new_hash;
 
     if is_head {
-        // Simple case: stage files and amend HEAD
         if !skip_staging {
             git::stage_files(workdir, &file_refs)?;
         }
@@ -835,12 +828,12 @@ fn fold_files_into_commit(
             return Err(e);
         }
 
-        // Re-read state after creating the fixup commit
         let fixup_hash = git::rev_parse(workdir, "HEAD")?;
         let fixup_oid = git2::Oid::from_str(&fixup_hash)?;
 
-        let repo = git2::Repository::discover(workdir)?;
-        let mut graph = Weave::from_repo(&repo)?;
+        // Re-open repo after creating the fixup commit (OIDs changed)
+        let repo2 = Repository::discover(workdir)?;
+        let mut graph = Weave::from_repo(&repo2)?;
         graph.fixup_commit(fixup_oid, target_oid)?;
 
         // Track target commit through the rebase via a temp branch.
@@ -856,8 +849,10 @@ fn fold_files_into_commit(
             files_count: files.len(),
             saved_staged: saved_staged.clone(),
         })?;
+        // saved_staged is stored in both rollback (for `loom abort`) and context
+        // (for `loom continue` → after_continue). Both paths are required.
         let loom_state = LoomState {
-            command: "fold".to_string(),
+            command: COMMAND.to_string(),
             rollback: Rollback {
                 saved_staged_patch: saved_staged.clone(),
                 delete_branches: vec![TRACK_BRANCH.to_string()],
@@ -876,7 +871,7 @@ fn fold_files_into_commit(
                 let _ = git::branch_delete(workdir, TRACK_BRANCH);
             }
             RebaseOutcome::Conflicted => {
-                transaction::warn_conflict_paused("fold");
+                transaction::warn_conflict_paused(COMMAND);
                 return Ok(());
             }
         }
@@ -894,9 +889,8 @@ fn fold_files_into_commit(
 
 /// Fold a commit into another commit (Case 2: Commit + Commit → Fixup).
 fn fold_commit_into_commit(repo: &Repository, source_hash: &str, target_hash: &str) -> Result<()> {
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
 
-    // Validate source is a descendant of target (source is newer)
     let source_oid = git2::Oid::from_str(source_hash)?;
     let target_oid = git2::Oid::from_str(target_hash)?;
 
@@ -922,7 +916,7 @@ fn fold_commit_into_commit(repo: &Repository, source_hash: &str, target_hash: &s
         target_hash: target_hash.to_string(),
     })?;
     let loom_state = LoomState {
-        command: "fold".to_string(),
+        command: COMMAND.to_string(),
         rollback: Rollback {
             delete_branches: vec![TRACK_BRANCH.to_string()],
             ..Default::default()
@@ -945,7 +939,7 @@ fn fold_commit_into_commit(repo: &Repository, source_hash: &str, target_hash: &s
             ));
         }
         RebaseOutcome::Conflicted => {
-            transaction::warn_conflict_paused("fold");
+            transaction::warn_conflict_paused(COMMAND);
         }
     }
 
@@ -954,7 +948,7 @@ fn fold_commit_into_commit(repo: &Repository, source_hash: &str, target_hash: &s
 
 /// Move a commit to a branch (Case 3: Commit + Branch → Move).
 fn fold_commit_to_branch(repo: &Repository, commit_hash: &str, branch_name: &str) -> Result<()> {
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
     let git_dir = repo.path().to_path_buf();
 
     let ctx = serde_json::to_value(FoldVariant::CommitToBranch {
@@ -962,7 +956,7 @@ fn fold_commit_to_branch(repo: &Repository, commit_hash: &str, branch_name: &str
         branch_name: branch_name.to_string(),
     })?;
     let state = LoomState {
-        command: "fold".to_string(),
+        command: COMMAND.to_string(),
         rollback: Rollback::default(),
         context: ctx,
     };
@@ -980,7 +974,7 @@ fn fold_commit_to_branch(repo: &Repository, commit_hash: &str, branch_name: &str
             ));
         }
         RebaseOutcome::Conflicted => {
-            transaction::warn_conflict_paused("fold");
+            transaction::warn_conflict_paused(COMMAND);
         }
     }
 
@@ -996,7 +990,7 @@ pub fn move_commit_to_branch(
     commit_hash: &str,
     branch_name: &str,
 ) -> Result<RebaseOutcome> {
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
 
     let commit_oid = git2::Oid::from_str(commit_hash)?;
 
@@ -1051,13 +1045,12 @@ pub fn move_commit_to_branch(
 /// directory as unstaged modifications. The commit itself is preserved (minus
 /// the file's changes).
 fn fold_commit_file_to_unstaged(repo: &Repository, commit_hash: &str, path: &str) -> Result<()> {
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
 
     let head_oid = repo::head_oid(repo)?;
     let target_oid = git2::Oid::from_str(commit_hash)?;
     let is_head = head_oid == target_oid;
 
-    // Get the file's diff from the commit
     let file_diff = git::diff_commit_file(workdir, commit_hash, path)?;
     if file_diff.is_empty() {
         bail!(
@@ -1070,11 +1063,8 @@ fn fold_commit_file_to_unstaged(repo: &Repository, commit_hash: &str, path: &str
     let new_hash;
 
     if is_head {
-        // Simple case: reverse the file's changes, amend HEAD, then re-apply
         let saved_head = head_oid.to_string();
-        git::apply_patch_reverse(workdir, &file_diff)?;
-        git::stage_path(workdir, path)?;
-        git::commit_amend_no_edit(workdir)?;
+        apply_and_amend_path(workdir, &file_diff, path, true)?;
         new_hash = git::rev_parse(workdir, "HEAD")?;
         if let Err(e) = git::apply_patch(workdir, &file_diff) {
             let _ = git::reset_hard(workdir, &saved_head);
@@ -1091,19 +1081,13 @@ fn fold_commit_file_to_unstaged(repo: &Repository, commit_hash: &str, path: &str
         let todo = graph.to_todo();
         weave::run_rebase_or_abort(workdir, Some(&graph.base_oid.to_string()), &todo)?;
 
-        // Paused at target — reverse the file, stage, amend
-        if let Err(e) = git::apply_patch_reverse(workdir, &file_diff)
-            .and_then(|()| git::stage_path(workdir, path))
-            .and_then(|()| git::commit_amend_no_edit(workdir))
-        {
+        if let Err(e) = apply_and_amend_path(workdir, &file_diff, path, true) {
             let _ = git::rebase_abort(workdir);
             return Err(e);
         }
 
-        // Capture new hash after amend, before continue moves HEAD
         new_hash = git::rev_parse(workdir, "HEAD")?;
 
-        // Continue the rebase
         git::continue_rebase_or_abort(workdir)?;
 
         // Re-apply changes to working tree
@@ -1136,7 +1120,7 @@ fn fold_commit_file_to_commit(
     path: &str,
     target_hash: &str,
 ) -> Result<()> {
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
 
     let source_oid = git2::Oid::from_str(source_hash)?;
     let target_oid = git2::Oid::from_str(target_hash)?;
@@ -1145,7 +1129,6 @@ fn fold_commit_file_to_commit(
         bail!("Source and target are the same commit");
     }
 
-    // Get the file's diff from the source commit
     let file_diff = git::diff_commit_file(workdir, source_hash, path)?;
     if file_diff.is_empty() {
         bail!(
@@ -1155,7 +1138,6 @@ fn fold_commit_file_to_commit(
         );
     }
 
-    // Check direction: is source a descendant of target (source is newer)?
     let source_is_newer = repo.graph_descendant_of(source_oid, target_oid)?;
 
     let new_source_hash;
@@ -1172,37 +1154,38 @@ fn fold_commit_file_to_commit(
         let saved_head = repo::head_oid(repo)?.to_string();
         let saved_refs = repo::snapshot_branch_refs(repo)?;
 
-        // Create a temp branch on target so --update-refs tracks its new OID
-        // through the phase 1 rebase. Created BEFORE from_repo() would include
-        // it in the graph, but after the graph snapshot — we create it right
-        // before the rebase so git's --update-refs picks it up.
+        let rollback =
+            |saved_head: &str, saved_refs: &std::collections::HashMap<String, git2::Oid>| {
+                let _ = git::branch_delete(workdir, TRACK_BRANCH);
+                let _ = git::reset_hard(workdir, saved_head);
+                if let Err(re) = repo::restore_branch_refs(workdir, saved_refs) {
+                    msg::warn(&format!("failed to restore branch refs: {re}"));
+                }
+            };
 
-        // Phase 1: edit at source, remove file, continue
+        // Phase 1: edit at source, remove file, continue.
+        // Create temp branch AFTER from_repo to avoid polluting the Weave graph,
+        // but before the rebase so git's --update-refs tracks the target's new OID.
         let mut graph = Weave::from_repo(repo)?;
         graph.edit_commit(source_oid);
         let todo = graph.to_todo();
-
-        // Create temp branch AFTER from_repo to avoid polluting the Weave graph
         git::branch_force_create(workdir, TRACK_BRANCH, target_hash)?;
 
-        let phase1_rebase =
-            weave::run_rebase_or_abort(workdir, Some(&graph.base_oid.to_string()), &todo);
-        if let Err(e) = phase1_rebase {
+        if let Err(e) =
+            weave::run_rebase_or_abort(workdir, Some(&graph.base_oid.to_string()), &todo)
+        {
             let _ = git::branch_delete(workdir, TRACK_BRANCH);
             return Err(e);
         }
 
-        if let Err(e) = git::apply_patch_reverse(workdir, &file_diff)
-            .and_then(|()| git::stage_path(workdir, path))
-            .and_then(|()| git::commit_amend_no_edit(workdir))
-        {
+        if let Err(e) = apply_and_amend_path(workdir, &file_diff, path, true) {
             let _ = git::rebase_abort(workdir);
             let _ = git::branch_delete(workdir, TRACK_BRANCH);
             return Err(e);
         }
 
-        // Capture source new hash after amend, before continue moves HEAD.
-        // This hash will be tracked through phase 2 via a temp branch.
+        // Capture source's new hash before continue moves HEAD;
+        // it will be tracked through phase 2 via a temp branch.
         let phase1_source_hash = git::rev_parse(workdir, "HEAD")?;
 
         if let Err(e) = git::continue_rebase_or_abort(workdir) {
@@ -1210,66 +1193,53 @@ fn fold_commit_file_to_commit(
             return Err(e);
         }
 
-        // Phase 2: Resolve the target's new OID via the temp branch.
+        // Phase 2: resolve the target's new OID via the temp branch.
         let phase2_target_hash = git::rev_parse(workdir, TRACK_BRANCH)?;
         let _ = git::branch_delete(workdir, TRACK_BRANCH);
         let phase2_target_oid = git2::Oid::from_str(&phase2_target_hash)?;
 
-        let repo2 = git2::Repository::discover(workdir)?;
-        let mut graph = Weave::from_repo(&repo2)?;
-        graph.edit_commit(phase2_target_oid);
+        // Re-open repo after phase 1 rebase (OIDs changed)
+        let repo2 = Repository::discover(workdir)?;
+        let mut graph2 = Weave::from_repo(&repo2)?;
+        graph2.edit_commit(phase2_target_oid);
 
         // Track source through phase 2 — it will be rewritten when the
         // graph is replayed from base_oid.
         let phase1_source_oid = git2::Oid::from_str(&phase1_source_hash)?;
         git::branch_force_create(workdir, TRACK_BRANCH, &phase1_source_hash)?;
-        graph.track_commit(phase1_source_oid, TRACK_BRANCH);
+        graph2.track_commit(phase1_source_oid, TRACK_BRANCH);
 
-        let todo = graph.to_todo();
+        let todo2 = graph2.to_todo();
 
         if let Err(e) =
-            weave::run_rebase_or_abort(workdir, Some(&graph.base_oid.to_string()), &todo)
+            weave::run_rebase_or_abort(workdir, Some(&graph2.base_oid.to_string()), &todo2)
         {
-            let _ = git::branch_delete(workdir, TRACK_BRANCH);
-            let _ = git::reset_hard(workdir, &saved_head);
-            if let Err(re) = repo::restore_branch_refs(workdir, &saved_refs) {
-                msg::warn(&format!("failed to restore branch refs: {re}"));
-            }
+            rollback(&saved_head, &saved_refs);
             return Err(e);
         }
 
-        if let Err(e) = git::apply_patch(workdir, &file_diff)
-            .and_then(|()| git::stage_path(workdir, path))
-            .and_then(|()| git::commit_amend_no_edit(workdir))
-        {
+        if let Err(e) = apply_and_amend_path(workdir, &file_diff, path, false) {
             let _ = git::rebase_abort(workdir);
-            let _ = git::branch_delete(workdir, TRACK_BRANCH);
-            let _ = git::reset_hard(workdir, &saved_head);
-            if let Err(re) = repo::restore_branch_refs(workdir, &saved_refs) {
-                msg::warn(&format!("failed to restore branch refs: {re}"));
-            }
+            rollback(&saved_head, &saved_refs);
             return Err(e);
         }
 
-        // Capture target new hash after amend, before continue moves HEAD
         new_target_hash = git::rev_parse(workdir, "HEAD")?;
 
         if let Err(e) = git::continue_rebase_or_abort(workdir) {
-            let _ = git::branch_delete(workdir, TRACK_BRANCH);
-            let _ = git::reset_hard(workdir, &saved_head);
-            if let Err(re) = repo::restore_branch_refs(workdir, &saved_refs) {
-                msg::warn(&format!("failed to restore branch refs: {re}"));
-            }
+            rollback(&saved_head, &saved_refs);
             return Err(e);
         }
 
-        // Resolve source's final hash after phase 2
         new_source_hash = git::rev_parse(workdir, TRACK_BRANCH)?;
         let _ = git::branch_delete(workdir, TRACK_BRANCH);
     } else {
         // Source is older than target: single rebase with two edit pauses.
         // Source is picked first (older), target second (newer). Removing
         // the file from source before target is replayed avoids conflicts.
+        let saved_head = repo::head_oid(repo)?.to_string();
+        let saved_refs = repo::snapshot_branch_refs(repo)?;
+
         let mut graph = Weave::from_repo(repo)?;
         graph.edit_commit(source_oid);
         graph.edit_commit(target_oid);
@@ -1277,31 +1247,24 @@ fn fold_commit_file_to_commit(
         let todo = graph.to_todo();
         weave::run_rebase_or_abort(workdir, Some(&graph.base_oid.to_string()), &todo)?;
 
-        // First pause: at source — remove file
-        if let Err(e) = git::apply_patch_reverse(workdir, &file_diff)
-            .and_then(|()| git::stage_path(workdir, path))
-            .and_then(|()| git::commit_amend_no_edit(workdir))
-        {
+        if let Err(e) = apply_and_amend_path(workdir, &file_diff, path, true) {
             let _ = git::rebase_abort(workdir);
             return Err(e);
         }
 
-        // Capture source new hash after amend, before continue moves HEAD
         new_source_hash = git::rev_parse(workdir, "HEAD")?;
 
-        // Continue to second pause: at target
         git::continue_rebase_or_abort(workdir)?;
 
-        // Second pause: at target — add file
-        if let Err(e) = git::apply_patch(workdir, &file_diff)
-            .and_then(|()| git::stage_path(workdir, path))
-            .and_then(|()| git::commit_amend_no_edit(workdir))
-        {
+        if let Err(e) = apply_and_amend_path(workdir, &file_diff, path, false) {
             let _ = git::rebase_abort(workdir);
+            let _ = git::reset_hard(workdir, &saved_head);
+            if let Err(re) = repo::restore_branch_refs(workdir, &saved_refs) {
+                msg::warn(&format!("failed to restore branch refs: {re}"));
+            }
             return Err(e);
         }
 
-        // Capture target new hash after amend, before continue moves HEAD
         new_target_hash = git::rev_parse(workdir, "HEAD")?;
 
         git::continue_rebase_or_abort(workdir)?;
@@ -1324,14 +1287,13 @@ fn fold_commit_file_to_commit(
 /// Removes the commit from history and places its changes in the working
 /// directory as unstaged modifications.
 fn fold_commit_to_unstaged(repo: &Repository, commit_hash: &str) -> Result<()> {
-    let workdir = repo::require_workdir(repo, "fold")?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
 
     let head_oid = repo::head_oid(repo)?;
     let target_oid = git2::Oid::from_str(commit_hash)?;
     let is_head = head_oid == target_oid;
 
     if is_head {
-        // Simple case: mixed reset to HEAD~1
         git::reset_mixed(workdir, "HEAD~1")?;
     } else {
         // Non-HEAD: capture the diff, drop the commit, then apply the diff
@@ -1349,7 +1311,7 @@ fn fold_commit_to_unstaged(repo: &Repository, commit_hash: &str) -> Result<()> {
             diff: diff.clone(),
         })?;
         let loom_state = LoomState {
-            command: "fold".to_string(),
+            command: COMMAND.to_string(),
             rollback: Rollback::default(),
             context: fold_ctx,
         };
@@ -1372,7 +1334,7 @@ fn fold_commit_to_unstaged(repo: &Repository, commit_hash: &str) -> Result<()> {
                 }
             }
             RebaseOutcome::Conflicted => {
-                transaction::warn_conflict_paused("fold");
+                transaction::warn_conflict_paused(COMMAND);
                 return Ok(());
             }
         }

--- a/src/git/git_diff.rs
+++ b/src/git/git_diff.rs
@@ -116,22 +116,18 @@ pub fn diff_commit_name_status(workdir: &Path, oid: &str) -> Result<Vec<(char, S
         if line.is_empty() {
             continue;
         }
-        let mut fields = line.splitn(2, '\t');
+        let mut fields = line.splitn(3, '\t');
         let status_field = fields.next().unwrap_or("");
-        let path_field = fields.next().unwrap_or("").trim();
-        if status_field.is_empty() || path_field.is_empty() {
+        let path1 = fields.next().unwrap_or("").trim();
+        let path2 = fields.next().map(str::trim);
+        if status_field.is_empty() || path1.is_empty() {
             continue;
         }
         let status = status_field.chars().next().unwrap_or('M');
         // For rename/copy entries (R/C), git outputs "old-path\tnew-path"; use the destination.
-        let path = if matches!(status, 'R' | 'C') {
-            path_field
-                .split('\t')
-                .next_back()
-                .unwrap_or(path_field)
-                .to_string()
-        } else {
-            path_field.to_string()
+        let path = match (status, path2) {
+            ('R' | 'C', Some(dest)) => dest.to_string(),
+            _ => path1.to_string(),
         };
         result.push((status, path));
     }

--- a/src/push.rs
+++ b/src/push.rs
@@ -81,7 +81,6 @@ pub fn run(branch: Option<String>, no_pr: bool) -> Result<()> {
     }
 }
 
-/// Resolve an explicit branch argument to a woven branch name.
 fn resolve_branch(repo: &Repository, info: &repo::RepoInfo, branch_arg: &str) -> Result<String> {
     let name = repo::resolve_arg(repo, branch_arg, &[repo::TargetKind::Branch])?.expect_branch()?;
     if info.branches.iter().any(|b| b.name == name) {
@@ -91,7 +90,6 @@ fn resolve_branch(repo: &Repository, info: &repo::RepoInfo, branch_arg: &str) ->
     }
 }
 
-/// Interactive branch picker: list woven branches.
 fn pick_branch(info: &repo::RepoInfo) -> Result<String> {
     let items: Vec<String> = info.branches.iter().map(|b| b.name.clone()).collect();
     msg::select("Select branch to push", items)
@@ -106,7 +104,6 @@ fn detect_remote_type(
     workdir: &Path,
     upstream_label: &str,
 ) -> Result<RemoteType> {
-    // 1. Check explicit config override
     if let Ok(config_value) = git::run_git_stdout(workdir, &["config", "--get", "loom.remote-type"])
     {
         let value = config_value.trim().to_lowercase();
@@ -127,36 +124,27 @@ fn detect_remote_type(
         ));
     }
 
-    // 2. Check remote URL for github.com
     let remote_name = extract_remote_name(upstream_label);
     if let Ok(remote) = repo.find_remote(&remote_name)
         && let Some(url) = remote.url()
-        && url.contains("github.com")
     {
-        return Ok(RemoteType::GitHub);
-    }
-
-    // 2b. Check remote URL for dev.azure.com
-    if let Ok(remote) = repo.find_remote(&remote_name)
-        && let Some(url) = remote.url()
-        && url.contains("dev.azure.com")
-    {
-        return Ok(RemoteType::AzureDevOps);
-    }
-
-    // 3. Check for Gerrit commit-msg hook
-    // Use repo.commondir() so this works in worktrees (where hooks are shared)
-    {
-        let hook_path = repo.commondir().join("hooks").join("commit-msg");
-        if let Ok(content) = std::fs::read_to_string(&hook_path)
-            && content.to_lowercase().contains("gerrit")
-        {
-            let target_branch = extract_target_branch(upstream_label);
-            return Ok(RemoteType::Gerrit { target_branch });
+        if url.contains("github.com") {
+            return Ok(RemoteType::GitHub);
+        }
+        if url.contains("dev.azure.com") {
+            return Ok(RemoteType::AzureDevOps);
         }
     }
 
-    // 4. Default to plain
+    // Use repo.commondir() so this works in worktrees (where hooks are shared)
+    let hook_path = repo.commondir().join("hooks").join("commit-msg");
+    if let Ok(content) = std::fs::read_to_string(&hook_path)
+        && content.to_lowercase().contains("gerrit")
+    {
+        let target_branch = extract_target_branch(upstream_label);
+        return Ok(RemoteType::Gerrit { target_branch });
+    }
+
     Ok(RemoteType::Plain)
 }
 
@@ -233,7 +221,6 @@ fn resolve_push_remote(
     upstream_label: &str,
     remote_type: &RemoteType,
 ) -> String {
-    // 1. Check explicit config override
     if let Ok(push_remote) = git::run_git_stdout(workdir, &["config", "--get", "loom.push-remote"])
     {
         let remote = push_remote.trim();
@@ -242,7 +229,6 @@ fn resolve_push_remote(
         }
     }
 
-    // 2. GitHub fork workflow: if upstream is "upstream" and origin exists, push to origin
     let remote_name = extract_remote_name(upstream_label);
     if *remote_type == RemoteType::GitHub
         && remote_name == "upstream"
@@ -254,7 +240,6 @@ fn resolve_push_remote(
     }
 }
 
-/// Force-with-lease push a branch to remote.
 fn git_push(workdir: &Path, remote: &str, branch: &str) -> Result<()> {
     git::run_git(
         workdir,
@@ -266,7 +251,9 @@ fn git_push(workdir: &Path, remote: &str, branch: &str) -> Result<()> {
             remote,
             branch,
         ],
-    )
+    )?;
+    msg::success(&format!("Pushed `{}` to `{}`", branch, remote));
+    Ok(())
 }
 
 /// Collect commits for a branch from oldest to newest, skipping merge commits.
@@ -325,7 +312,6 @@ fn pr_title_and_description(
         return Ok((subject.clone(), body.clone()));
     }
 
-    // Multiple commits: ask the user for a title
     let title = msg::input("PR title", |s| {
         if s.is_empty() {
             Err("Title cannot be empty")
@@ -349,11 +335,8 @@ fn pr_title_and_description(
     Ok((title, description))
 }
 
-/// Push using plain git with force-with-lease.
 fn push_plain(workdir: &Path, remote: &str, branch: &str) -> Result<()> {
-    git_push(workdir, remote, branch)?;
-    msg::success(&format!("Pushed `{}` to `{}`", branch, remote));
-    Ok(())
+    git_push(workdir, remote, branch)
 }
 
 /// Push to GitHub: push the branch, then open `gh pr create --web`.
@@ -379,14 +362,12 @@ fn push_github(
     upstream_label: &str,
 ) -> Result<()> {
     git_push(workdir, remote, branch)?;
-    msg::success(&format!("Pushed `{}` to `{}`", branch, remote));
 
     // Skip PR creation when pushing the upstream target branch itself
     if branch == target_branch {
         return Ok(());
     }
 
-    // Check if gh CLI is available
     let start = Instant::now();
     let gh_check = Command::new("gh").arg("--version").output();
     let gh_available = gh_check.as_ref().is_ok_and(|o| o.status.success());
@@ -427,7 +408,6 @@ fn push_github(
         branch.to_string()
     };
 
-    // If a PR already exists, show its URL instead of opening the browser
     if let Some(pr_url) = find_existing_github_pr(workdir, &pr_target_repo, branch) {
         msg::success(&format!("PR updated: {}", pr_url));
         return Ok(());
@@ -554,7 +534,6 @@ fn push_azure(
     base_oid: git2::Oid,
 ) -> Result<()> {
     git_push(workdir, remote, branch)?;
-    msg::success(&format!("Pushed `{}` to `{}`", branch, remote));
 
     let start = Instant::now();
     let az_check = az_command().arg("--version").output();
@@ -702,14 +681,13 @@ fn push_gerrit_no_pr(workdir: &Path, remote: &str, branch: &str) -> Result<()> {
 
     let opt_as_is = format!("Push as `{}` (admin required to delete it later)", branch);
     let opt_wip = format!("Push as `wip/{}` instead", branch);
-    let opt_cancel = "Cancel".to_string();
 
     let choice = msg::select(
         &format!(
             "Branch `{}` is not prefixed with `wip/` — a Gerrit admin will be needed to delete the remote branch later",
             branch
         ),
-        vec![opt_as_is.clone(), opt_wip.clone(), opt_cancel],
+        vec![opt_as_is.clone(), opt_wip.clone(), "Cancel".to_string()],
     )?;
 
     if choice == opt_as_is {
@@ -761,7 +739,6 @@ fn push_gerrit(workdir: &Path, remote: &str, branch: &str, target_branch: &str) 
         bail!("Git {} failed", cmd);
     }
 
-    // Extract Gerrit review URLs from remote output
     let mut message = format!(
         "Pushed `{}` to `{}` (Gerrit: `refs/for/{}`)",
         branch, remote, target_branch

--- a/src/split.rs
+++ b/src/split.rs
@@ -167,7 +167,7 @@ fn perform_split(
     // Save pre-existing staged changes so reset --mixed doesn't discard them.
     // (For non-HEAD splits, the rebase autostash handles this, but saving
     // here is harmless — it will be empty.)
-    let saved_staged = save_staged(repo, workdir)?;
+    let saved_staged = staging::save_and_unstage_staged(repo, workdir)?;
 
     let split_result = if is_head {
         perform_head_split(workdir, selected, remaining, msg1, msg2)
@@ -274,7 +274,7 @@ fn perform_split_by_hunks(
     let oid_str = commit_oid.to_string();
     let short_hash = git::short_hash(&oid_str);
 
-    let saved_staged = save_staged(repo, workdir)?;
+    let saved_staged = staging::save_and_unstage_staged(repo, workdir)?;
 
     let split_result = if is_head {
         perform_head_split_by_hunks(workdir, selections, msg1, msg2)
@@ -366,18 +366,6 @@ fn perform_non_head_split_by_hunks(
 
     git::continue_rebase_or_abort(workdir)?;
     Ok((hash1, hash2))
-}
-
-/// Save all staged changes aside so they can be restored after the split.
-fn save_staged(repo: &Repository, workdir: &std::path::Path) -> Result<String> {
-    let staged = repo::get_staged_files(repo)?;
-    if staged.is_empty() {
-        return Ok(String::new());
-    }
-    let refs: Vec<&str> = staged.iter().map(|s| s.as_str()).collect();
-    let patch = git::diff_cached_files(workdir, &refs)?;
-    git::unstage_files(workdir, &refs)?;
-    Ok(patch)
 }
 
 #[cfg(test)]

--- a/src/split.rs
+++ b/src/split.rs
@@ -7,6 +7,8 @@ use crate::core::{diff, graph, msg, staging};
 use crate::git;
 use crate::tui::hunk_selector::FileEntry;
 
+const COMMAND: &str = "split";
+
 /// Commit with `-m` message or open the editor.
 fn commit_or_editor(workdir: &std::path::Path, message: Option<&str>) -> Result<()> {
     match message {
@@ -45,9 +47,9 @@ fn split_commit(
     files: Vec<String>,
     theme: &graph::Theme,
 ) -> Result<()> {
-    let workdir = repo::require_workdir(repo, "split")?;
-    let commit_oid = repo.revparse_single(commit_hash)?.peel_to_commit()?.id();
-    let commit = repo.find_commit(commit_oid)?;
+    let workdir = repo::require_workdir(repo, COMMAND)?;
+    let commit = repo.revparse_single(commit_hash)?.peel_to_commit()?;
+    let commit_oid = commit.id();
 
     if commit.parent_count() > 1 {
         bail!("Cannot split a merge commit");
@@ -83,7 +85,6 @@ fn split_commit(
         );
     }
 
-    // File-based split
     let all_files = repo::commit_file_paths(repo, commit_oid)?;
     if all_files.len() < 2 {
         bail!("Cannot split a commit with only one file");
@@ -149,7 +150,60 @@ fn pick_files(files: &[String]) -> Result<Vec<String>> {
     Ok(selected)
 }
 
-/// Perform the actual split operation.
+/// Shared split dispatcher: save staged, run split logic, restore staged, print success.
+///
+/// `do_split` receives `is_head: bool` and returns `(hash1, hash2)`.
+fn run_split(
+    repo: &Repository,
+    workdir: &std::path::Path,
+    commit_oid: Oid,
+    do_split: impl FnOnce(bool) -> Result<(String, String)>,
+) -> Result<()> {
+    let is_head = repo::head_oid(repo)? == commit_oid;
+    let oid_str = commit_oid.to_string();
+    let short_hash = git::short_hash(&oid_str);
+    // Save pre-existing staged changes so reset --mixed doesn't discard them.
+    // (For non-HEAD splits, the rebase autostash handles this, but saving
+    // here is harmless — it will be empty.)
+    let saved_staged = staging::save_and_unstage_staged(repo, workdir)?;
+    let split_result = do_split(is_head);
+    // Restore pre-existing staged changes regardless of outcome.
+    git::restore_staged_patch(workdir, &saved_staged)?;
+    let (h1, h2) = split_result?;
+    msg::success(&format!(
+        "Split `{}` into `{}` and `{}`",
+        short_hash,
+        git::short_hash(&h1),
+        git::short_hash(&h2)
+    ));
+    Ok(())
+}
+
+/// Wrap a head-split closure in an edit-and-continue rebase for non-HEAD commits.
+///
+/// Aborts the rebase automatically on error — split does not save LoomState.
+fn perform_non_head_with(
+    repo: &Repository,
+    workdir: &std::path::Path,
+    commit_oid: Oid,
+    do_head_split: impl FnOnce() -> Result<(String, String)>,
+) -> Result<(String, String)> {
+    weave::start_edit_rebase(repo, workdir, commit_oid)?;
+    let result = match do_head_split() {
+        Ok(hashes) => hashes,
+        Err(e) => {
+            let _ = git::rebase_abort(workdir);
+            return Err(e);
+        }
+    };
+    // Continue the rebase — later commits are replayed on top of the split
+    // commits, so hash1 and hash2 remain valid (they are ancestors).
+    // Abort automatically on conflict — split does not save LoomState.
+    git::continue_rebase_or_abort(workdir)?;
+    Ok(result)
+}
+
+/// Perform the file-based split operation.
 fn perform_split(
     repo: &Repository,
     workdir: &std::path::Path,
@@ -159,34 +213,15 @@ fn perform_split(
     msg1: Option<&str>,
     msg2: &str,
 ) -> Result<()> {
-    let head_oid = repo::head_oid(repo)?;
-    let is_head = head_oid == commit_oid;
-    let oid_str = commit_oid.to_string();
-    let short_hash = git::short_hash(&oid_str);
-
-    // Save pre-existing staged changes so reset --mixed doesn't discard them.
-    // (For non-HEAD splits, the rebase autostash handles this, but saving
-    // here is harmless — it will be empty.)
-    let saved_staged = staging::save_and_unstage_staged(repo, workdir)?;
-
-    let split_result = if is_head {
-        perform_head_split(workdir, selected, remaining, msg1, msg2)
-    } else {
-        perform_non_head_split(repo, workdir, commit_oid, selected, remaining, msg1, msg2)
-    };
-
-    // Restore pre-existing staged changes regardless of outcome.
-    git::restore_staged_patch(workdir, &saved_staged)?;
-
-    let (new_hash1, new_hash2) = split_result?;
-
-    msg::success(&format!(
-        "Split `{}` into `{}` and `{}`",
-        short_hash,
-        git::short_hash(&new_hash1),
-        git::short_hash(&new_hash2)
-    ));
-    Ok(())
+    run_split(repo, workdir, commit_oid, |is_head| {
+        if is_head {
+            perform_head_split(workdir, selected, remaining, msg1, msg2)
+        } else {
+            perform_non_head_with(repo, workdir, commit_oid, || {
+                perform_head_split(workdir, selected, remaining, msg1, msg2)
+            })
+        }
+    })
 }
 
 /// Split HEAD commit (no rebase needed).
@@ -213,49 +248,8 @@ fn perform_head_split(
     git::stage_files(workdir, &remaining_refs)?;
     git::commit(workdir, msg2)?;
 
-    // HEAD is the second commit, HEAD~1 is the first
     let hash2 = git::rev_parse(workdir, "HEAD")?;
     let hash1 = git::rev_parse(workdir, "HEAD~1")?;
-
-    Ok((hash1, hash2))
-}
-
-/// Split a non-HEAD commit using edit-and-continue rebase.
-///
-/// ```text
-/// Weave::from_repo → edit_commit(oid) → run_rebase (pauses)
-/// → reset_mixed(HEAD~1) → stage selected → commit(msg1)
-/// → stage remaining → commit(msg2)
-/// → continue_rebase
-/// ```
-///
-/// Returns `(hash1, hash2)` — the two new commit hashes.
-fn perform_non_head_split(
-    repo: &Repository,
-    workdir: &std::path::Path,
-    commit_oid: Oid,
-    selected: &[String],
-    remaining: &[String],
-    msg1: Option<&str>,
-    msg2: &str,
-) -> Result<(String, String)> {
-    // Start edit rebase
-    weave::start_edit_rebase(repo, workdir, commit_oid)?;
-
-    // Now paused at the target commit — split it (same as HEAD split since
-    // the rebase has made the target commit HEAD).
-    let (hash1, hash2) = match perform_head_split(workdir, selected, remaining, msg1, msg2) {
-        Ok(hashes) => hashes,
-        Err(e) => {
-            let _ = git::rebase_abort(workdir);
-            return Err(e);
-        }
-    };
-
-    // Continue the rebase — later commits are replayed on top of the split
-    // commits, so hash1 and hash2 remain valid (they are ancestors).
-    // Abort automatically on conflict — split does not save LoomState.
-    git::continue_rebase_or_abort(workdir)?;
 
     Ok((hash1, hash2))
 }
@@ -269,30 +263,15 @@ fn perform_split_by_hunks(
     msg1: Option<&str>,
     msg2: &str,
 ) -> Result<()> {
-    let head_oid = repo::head_oid(repo)?;
-    let is_head = head_oid == commit_oid;
-    let oid_str = commit_oid.to_string();
-    let short_hash = git::short_hash(&oid_str);
-
-    let saved_staged = staging::save_and_unstage_staged(repo, workdir)?;
-
-    let split_result = if is_head {
-        perform_head_split_by_hunks(workdir, selections, msg1, msg2)
-    } else {
-        perform_non_head_split_by_hunks(repo, workdir, commit_oid, selections, msg1, msg2)
-    };
-
-    git::restore_staged_patch(workdir, &saved_staged)?;
-
-    let (new_hash1, new_hash2) = split_result?;
-
-    msg::success(&format!(
-        "Split `{}` into `{}` and `{}`",
-        short_hash,
-        git::short_hash(&new_hash1),
-        git::short_hash(&new_hash2)
-    ));
-    Ok(())
+    run_split(repo, workdir, commit_oid, |is_head| {
+        if is_head {
+            perform_head_split_by_hunks(workdir, selections, msg1, msg2)
+        } else {
+            perform_non_head_with(repo, workdir, commit_oid, || {
+                perform_head_split_by_hunks(workdir, selections, msg1, msg2)
+            })
+        }
+    })
 }
 
 /// HEAD hunk-based split.
@@ -308,7 +287,6 @@ fn perform_head_split_by_hunks(
 ) -> Result<(String, String)> {
     git::reset_mixed(workdir, "HEAD~1")?;
 
-    // Stage selected hunks for the first commit.
     let mut selected_patch = String::new();
     for file in selections {
         let selected: Vec<_> = file
@@ -332,7 +310,6 @@ fn perform_head_split_by_hunks(
 
     commit_or_editor(workdir, msg1)?;
 
-    // Stage remaining changes for the second commit.
     for file in selections {
         if file.hunks.iter().any(|h| !h.selected) {
             git::stage_path(workdir, &file.path)?;
@@ -342,29 +319,6 @@ fn perform_head_split_by_hunks(
 
     let hash2 = git::rev_parse(workdir, "HEAD")?;
     let hash1 = git::rev_parse(workdir, "HEAD~1")?;
-    Ok((hash1, hash2))
-}
-
-/// Non-HEAD hunk-based split using edit-and-continue rebase.
-fn perform_non_head_split_by_hunks(
-    repo: &Repository,
-    workdir: &std::path::Path,
-    commit_oid: Oid,
-    selections: &[FileEntry],
-    msg1: Option<&str>,
-    msg2: &str,
-) -> Result<(String, String)> {
-    weave::start_edit_rebase(repo, workdir, commit_oid)?;
-
-    let (hash1, hash2) = match perform_head_split_by_hunks(workdir, selections, msg1, msg2) {
-        Ok(hashes) => hashes,
-        Err(e) => {
-            let _ = git::rebase_abort(workdir);
-            return Err(e);
-        }
-    };
-
-    git::continue_rebase_or_abort(workdir)?;
     Ok((hash1, hash2))
 }
 


### PR DESCRIPTION
refactor: simplify fold/split/staging code

- Extract shared `save_and_unstage_staged` to staging.rs, removing
  duplicate from fold.rs and split.rs
- Extract `apply_and_amend_path` helper in fold.rs to replace 5
  repeated apply→stage→amend triples for single-file operations
- Unify `apply_and_amend`/`reverse_apply_and_amend` into a single
  function with a `reverse` parameter
- Remove redundant `git2::Repository::discover` calls; reuse the
  `repo` parameter already in scope
- Add `rollback` closure in `fold_commit_file_to_commit` phase 2 to
  replace three copy-pasted rollback blocks
- Fix missing `snapshot_branch_refs` rollback in the "source is older"
  path of `fold_commit_file_to_commit` — a failure at the second edit
  pause previously left branch refs in a corrupted state
- Fix `recurse_untracked_dirs(false)` → `true` in
  `collect_changed_files`; the old setting emitted directory names
  instead of file paths for new subdirectories, causing `zz` expansion
  to silently stage nothing
- Add `const COMMAND: &str = "fold"` and replace all 17 inline "fold"
  string literals to prevent silent dispatch mismatches
- Fix `diff_commit_name_status` to use `splitn(3, '\t')` for cleaner
  rename/copy path extraction
- Remove several "what" comments; keep only non-obvious "why" comments

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

refactor: simplify split.rs

- Extract `run_split` shared dispatcher to eliminate duplicated
  boilerplate (save staged / head-or-non-head dispatch / restore staged /
  success message) that was copy-pasted across `perform_split` and
  `perform_split_by_hunks`
- Extract `perform_non_head_with` closure-based helper to eliminate
  `perform_non_head_split` and `perform_non_head_split_by_hunks`, which
  were structurally identical (start_edit_rebase / call inner / abort on
  error / continue_rebase_or_abort)
- Fix redundant `find_commit` after `peel_to_commit` — one fewer
  object-database lookup
- Add `const COMMAND: &str = "split"` to match fold.rs convention
- Remove four "what" comments

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

refactor: simplify absorb.rs

- Build commit-to-branch index once in build_plan instead of O(n) per-call linear scan
- Use CommitInfo.short_id in commit_label instead of manual git::short_hash truncation
- Extract commit_fixup helper to remove duplicate subject-lookup/commit/rev-parse tail
- Remove redundant diff_head_name_only pre-flight in save_skipped_patch
- Remove WHAT comment; tighten adjacent comment to WHY only

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

refactor: simplify commit.rs, consolidate shared helpers

- Move resolve_file_arg and verify_has_staged_changes to core/repo.rs
- Move save_and_unstage_other_staged to core/staging.rs
- Remove fold.rs dependency on commit module (used only for verify_has_staged_changes)
- Extract resolve_file_args helper to remove duplicated loop in commit.rs
- Extract do_commit closure to remove duplicated git::commit/git::commit_with_editor block
- Return (branch_name, is_new) from resolve_branch_target to eliminate full branch list enumeration
- Remove WHAT comments; tighten remaining comments to WHY only

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

refactor: simplify drop.rs, use confirm_or_bail helper and commit_subject

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

refactor: simplify push.rs, merge find_remote calls, consolidate push message

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

refactor: small cleanup on fold