### PR TITLE
Hunk improvement: mouse and scrollbars

### DIFF
--- a/src/tui/hunk_selector.rs
+++ b/src/tui/hunk_selector.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
+    MouseButton, MouseEventKind,
+};
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Position, Rect},
     style::Modifier,
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
@@ -124,6 +127,9 @@ struct HunkSelectorApp {
     should_quit: bool,
     confirmed: bool,
     scroll_offset: u16,
+    /// Cached layout rects for mouse hit-testing (updated each render).
+    left_pane_area: Rect,
+    right_pane_area: Rect,
 }
 
 // ---------------------------------------------------------------------------
@@ -190,6 +196,8 @@ impl HunkSelectorApp {
             should_quit: false,
             confirmed: false,
             scroll_offset: 0,
+            left_pane_area: Rect::default(),
+            right_pane_area: Rect::default(),
         }
     }
 
@@ -219,6 +227,8 @@ impl HunkSelectorApp {
             .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
             .split(outer[0]);
 
+        self.left_pane_area = panes[0];
+        self.right_pane_area = panes[1];
         self.render_file_list(frame, panes[0]);
         self.render_diff_view(frame, panes[1]);
         self.render_status_bar(frame, outer[1]);
@@ -427,6 +437,85 @@ impl HunkSelectorApp {
         }
     }
 
+    fn handle_mouse(&mut self, kind: MouseEventKind, col: u16, row: u16) {
+        let pos = Position { x: col, y: row };
+
+        if self.left_pane_area.contains(pos) {
+            match kind {
+                MouseEventKind::Down(MouseButton::Left) => {
+                    // Inner area: subtract 1-row border top.
+                    let inner_top = self.left_pane_area.y + 1;
+                    if row < inner_top {
+                        return;
+                    }
+                    let clicked = (row - inner_top) as usize;
+                    if clicked < self.display_rows.len() {
+                        self.cursor_pos = clicked;
+                        self.hunk_index = 0;
+                        self.scroll_offset = 0;
+                        self.active_pane = Pane::Left;
+                    }
+                }
+                MouseEventKind::ScrollUp => {
+                    if self.cursor_pos > 0 {
+                        self.cursor_pos -= 1;
+                        self.hunk_index = 0;
+                        self.scroll_offset = 0;
+                    }
+                }
+                MouseEventKind::ScrollDown => {
+                    if self.cursor_pos + 1 < self.display_rows.len() {
+                        self.cursor_pos += 1;
+                        self.hunk_index = 0;
+                        self.scroll_offset = 0;
+                    }
+                }
+                _ => {}
+            }
+        } else if self.right_pane_area.contains(pos) {
+            match kind {
+                MouseEventKind::Down(MouseButton::Left) => {
+                    self.active_pane = Pane::Right;
+                    let file_idx = match self.current_file_index() {
+                        Some(i) => i,
+                        None => return,
+                    };
+                    // Inner area: subtract 1-row border top, then account for scroll.
+                    let inner_top = self.right_pane_area.y + 1;
+                    if row < inner_top {
+                        return;
+                    }
+                    let clicked_line = (row - inner_top) as u16 + self.scroll_offset;
+                    // Walk hunks to find which one was clicked.
+                    let file = &self.files[file_idx];
+                    let total = file.hunks.len();
+                    let mut line: u16 = 0;
+                    for (i, entry) in file.hunks.iter().enumerate() {
+                        let hunk_lines = 1 + entry.hunk.text.lines().count() as u16;
+                        let separator = if i + 1 < total { 1 } else { 0 };
+                        if clicked_line < line + hunk_lines {
+                            // Clicked inside this hunk — toggle if on header row.
+                            self.hunk_index = i;
+                            if clicked_line == line {
+                                let h = &mut self.files[file_idx].hunks[i];
+                                h.selected = !h.selected;
+                            }
+                            return;
+                        }
+                        line += hunk_lines + separator;
+                    }
+                }
+                MouseEventKind::ScrollUp => {
+                    self.scroll_offset = self.scroll_offset.saturating_sub(3);
+                }
+                MouseEventKind::ScrollDown => {
+                    self.scroll_offset += 3;
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn navigate_up(&mut self) {
         if self.display_rows.is_empty() {
             return;
@@ -585,11 +674,13 @@ pub fn run_hunk_selector(files: Vec<FileEntry>, theme: TuiTheme) -> Result<Optio
     }
 
     let mut terminal = ratatui::init();
+    crossterm::execute!(std::io::stdout(), EnableMouseCapture)?;
 
     // Panic-safe cleanup: install a hook that restores the terminal before the
     // default handler fires.
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
+        let _ = crossterm::execute!(std::io::stdout(), DisableMouseCapture);
         ratatui::restore();
         prev_hook(info);
     }));
@@ -597,6 +688,7 @@ pub fn run_hunk_selector(files: Vec<FileEntry>, theme: TuiTheme) -> Result<Optio
     let result = run_event_loop(&mut terminal, files, theme);
 
     // Restore terminal state on normal exit.
+    crossterm::execute!(std::io::stdout(), DisableMouseCapture)?;
     ratatui::restore();
 
     // Remove our custom panic hook — back to default.
@@ -615,12 +707,18 @@ fn run_event_loop(
     loop {
         terminal.draw(|frame| app.render(frame))?;
 
-        if let Event::Key(key) = event::read()? {
-            // On Windows, crossterm fires both Press and Release. Only handle Press.
-            if key.kind != KeyEventKind::Press {
-                continue;
+        match event::read()? {
+            Event::Key(key) => {
+                // On Windows, crossterm fires both Press and Release. Only handle Press.
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                app.handle_key(key.code, key.modifiers);
             }
-            app.handle_key(key.code, key.modifiers);
+            Event::Mouse(mouse) => {
+                app.handle_mouse(mouse.kind, mouse.column, mouse.row);
+            }
+            _ => {}
         }
 
         if app.should_quit {

--- a/src/tui/hunk_selector.rs
+++ b/src/tui/hunk_selector.rs
@@ -5,10 +5,13 @@ use crossterm::event::{
 };
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction, Layout, Position, Rect},
+    layout::{Constraint, Direction, Layout, Margin, Position, Rect},
     style::Modifier,
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{
+        Block, Borders, List, ListItem, ListState, Paragraph, Scrollbar, ScrollbarOrientation,
+        ScrollbarState, Wrap,
+    },
 };
 
 use crate::core::diff::DiffHunk;
@@ -302,9 +305,39 @@ impl HunkSelectorApp {
         let mut state = ListState::default();
         state.select(Some(self.cursor_pos));
         frame.render_stateful_widget(list, area, &mut state);
+
+        // Scrollbar — only when the list overflows the visible inner height.
+        let inner = area.inner(Margin {
+            horizontal: 1,
+            vertical: 1,
+        });
+        let inner_height = inner.height as usize;
+        let total = self.display_rows.len();
+        if total > inner_height {
+            // Ratatui maps thumb to bottom when position = content_length - 1.
+            // Setting content_length = max_pos + 1 makes the max scroll position
+            // land at content_length - 1, and gives thumb_size = track * inner_height
+            // / total_rows (the correct visible fraction).
+            let max_pos = total - inner_height;
+            let mut sb_state = ScrollbarState::new(max_pos + 1)
+                .position(self.cursor_pos.min(max_pos))
+                .viewport_content_length(inner_height);
+            let sb_area = area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            });
+            frame.render_stateful_widget(
+                Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                    .begin_symbol(None)
+                    .end_symbol(None)
+                    .track_symbol(None),
+                sb_area,
+                &mut sb_state,
+            );
+        }
     }
 
-    fn render_diff_view(&self, frame: &mut Frame, area: Rect) {
+    fn render_diff_view(&mut self, frame: &mut Frame, area: Rect) {
         let border_style = if self.active_pane == Pane::Right {
             self.theme.border_active
         } else {
@@ -389,12 +422,64 @@ impl HunkSelectorApp {
             }
         }
 
+        // Two empty lines at the bottom for breathing room.
+        lines.push(Line::from(""));
+        lines.push(Line::from(""));
+
+        let inner = area.inner(Margin {
+            horizontal: 1,
+            vertical: 1,
+        });
+        let inner_width = inner.width as usize;
+        let inner_height = inner.height as usize;
+
+        // With wrapping enabled, each logical line may span multiple rendered rows.
+        // Compute total rendered rows so the scrollbar reflects actual content height.
+        let total_rows: usize = lines
+            .iter()
+            .map(|line| {
+                let width: usize = line.spans.iter().map(|s| s.content.chars().count()).sum();
+                if inner_width == 0 || width == 0 {
+                    1
+                } else {
+                    width.div_ceil(inner_width)
+                }
+            })
+            .sum();
+
+        // Clamp scroll so the last line of content is always at the bottom.
+        let max_scroll = total_rows.saturating_sub(inner_height) as u16;
+        self.scroll_offset = self.scroll_offset.min(max_scroll);
+
         let paragraph = Paragraph::new(lines)
             .block(block)
             .wrap(Wrap { trim: false })
             .scroll((self.scroll_offset, 0));
 
         frame.render_widget(paragraph, area);
+
+        if total_rows > inner_height {
+            // Ratatui maps thumb to bottom when position = content_length - 1.
+            // Setting content_length = max_scroll + 1 makes scroll_offset = max_scroll
+            // land at content_length - 1, and gives thumb_size = track * inner_height
+            // / total_rows (the correct visible fraction).
+            let max_scroll_usize = total_rows - inner_height;
+            let mut sb_state = ScrollbarState::new(max_scroll_usize + 1)
+                .position(self.scroll_offset as usize)
+                .viewport_content_length(inner_height);
+            let sb_area = area.inner(Margin {
+                horizontal: 0,
+                vertical: 1,
+            });
+            frame.render_stateful_widget(
+                Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                    .begin_symbol(None)
+                    .end_symbol(None)
+                    .track_symbol(None),
+                sb_area,
+                &mut sb_state,
+            );
+        }
     }
 
     fn render_status_bar(&self, frame: &mut Frame, area: Rect) {
@@ -485,7 +570,7 @@ impl HunkSelectorApp {
                     if row < inner_top {
                         return;
                     }
-                    let clicked_line = (row - inner_top) as u16 + self.scroll_offset;
+                    let clicked_line = row - inner_top + self.scroll_offset;
                     // Walk hunks to find which one was clicked.
                     let file = &self.files[file_idx];
                     let total = file.hunks.len();


### PR DESCRIPTION
feat: add mouse support to hunk selector TUI

Enable click-to-select file, click-to-switch-pane, click-to-toggle hunk,
and scroll wheel navigation. Right pane scroll moves the viewport only,
without auto-advancing to the next file.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

feat: add scrollbar to file list and diff pane in hunk selector

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>