### PR TITLE
feat(diff): add --staged and --all flags to match git diff

### DIFF
--- a/docs/src/commands/diff.md
+++ b/docs/src/commands/diff.md
@@ -5,7 +5,7 @@ Show a diff using short IDs, like `git diff`.
 ## Usage
 
 ```
-git loom diff [args...]
+git loom diff [args...] [--staged] [--all]
 ```
 
 Alias: `di`
@@ -18,11 +18,20 @@ Each argument is a file, commit, or commit range. Arguments can be mixed freely 
 |----------|-------------|
 | `[args...]` | Files (short ID or path), commits (short ID, hash), or ranges (`left..right`) |
 
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--staged` (alias `--cached`) | Show staged changes (index vs `HEAD`) |
+| `-a`, `--all` | Show all changes, staged and unstaged combined (working tree vs `HEAD`) |
+
+`--staged` and `--all` are mutually exclusive. With neither flag, only unstaged changes are shown, exactly like `git diff`.
+
 ## What It Does
 
 ### When No Arguments Are Given
 
-Shows unstaged changes in the working tree — identical to `git diff` with no arguments.
+Shows unstaged changes in the working tree — identical to `git diff` with no arguments. Use `--staged` to show staged changes instead, or `--all` to show both.
 
 ### When a Commit Is Given
 
@@ -30,7 +39,7 @@ Resolves the token to a full hash and passes it to `git diff`, showing the diff 
 
 ### When a File Is Given
 
-Resolves the token to a file path and runs `git diff HEAD -- <path>`, showing all changes to that file since `HEAD` (staged and unstaged combined).
+Resolves the token to a file path and runs `git diff -- <path>`, showing unstaged changes to that file. With `--staged` the staged changes are shown (`git diff --staged -- <path>`); with `--all` both are shown (`git diff HEAD -- <path>`).
 
 ### When a Commit Range Is Given
 
@@ -64,6 +73,20 @@ git loom diff
 # Equivalent to: git diff
 ```
 
+### Show staged changes
+
+```bash
+git loom diff --staged
+# Equivalent to: git diff --staged
+```
+
+### Show all changes, staged and unstaged
+
+```bash
+git loom diff --all
+# Equivalent to: git diff HEAD
+```
+
 ### Diff a commit by short ID
 
 ```bash
@@ -75,7 +98,7 @@ git loom diff ab
 
 ```bash
 git loom diff ma
-# Shows all changes to the file with short ID "ma" since HEAD
+# Shows unstaged changes to the file with short ID "ma"
 ```
 
 ### Diff a commit range

--- a/specs/016-diff.md
+++ b/specs/016-diff.md
@@ -31,7 +31,7 @@ other loom command.
 ## CLI
 
 ```bash
-git-loom diff [args...]
+git-loom diff [args...] [--staged] [--all]
 ```
 
 **Alias:** `di`
@@ -46,12 +46,26 @@ git-loom diff [args...]
 
   Tokens can be mixed freely (e.g. a commit and a file in the same invocation).
 
+**Options:**
+
+- `--staged` (alias `--cached`): Show staged changes (index vs `HEAD`) instead
+  of unstaged changes.
+- `-a`, `--all`: Show all changes, staged and unstaged combined (working tree
+  vs `HEAD`).
+
+`--staged` and `--all` are mutually exclusive. With neither flag, the command
+shows unstaged changes only, exactly like `git diff`.
+
 ## What Happens
 
 ### When No Arguments Are Given
 
 `git diff` is invoked with no additional arguments, showing the diff between
 the working tree and the index (unstaged changes), exactly as `git diff` does.
+
+With `--staged`, `git diff --staged` is invoked instead, showing staged
+changes (index vs `HEAD`). With `--all`, `git diff HEAD` is invoked, showing
+both staged and unstaged changes in one view.
 
 **What changes:** nothing — this is a read-only inspection command.
 
@@ -70,9 +84,11 @@ given commit and the working tree, including both staged and unstaged changes.
 ### When a File Is Given
 
 The token is resolved to a repository-relative file path (via short ID lookup
-or direct path lookup) and passed to `git diff HEAD -- <path>`. This shows all
-changes to that file since `HEAD`, meaning both staged and unstaged changes are
-included in a single view.
+or direct path lookup) and passed to `git diff -- <path>`, showing unstaged
+changes to that file. The `--staged` and `--all` flags apply the same way as
+with no arguments: `--staged` shows staged changes
+(`git diff --staged -- <path>`) and `--all` shows both
+(`git diff HEAD -- <path>`).
 
 **What changes:** nothing.
 
@@ -138,6 +154,20 @@ git-loom diff
 # Equivalent to: git diff
 ```
 
+### Show staged changes
+
+```
+git-loom diff --staged
+# Equivalent to: git diff --staged
+```
+
+### Show all changes (staged and unstaged)
+
+```
+git-loom diff --all
+# Equivalent to: git diff HEAD
+```
+
 ### Diff a single commit by short ID
 
 ```
@@ -155,7 +185,7 @@ git-loom status
 # M  ma  src/auth/login.rs
 
 git-loom diff ma
-# Shows all changes to src/auth/login.rs since HEAD (staged + unstaged)
+# Shows unstaged changes to src/auth/login.rs
 ```
 
 ### Diff a commit range using short IDs
@@ -202,14 +232,13 @@ intentional: ranges frequently mix short IDs with standard git refs like
 forms. If a token is genuinely invalid, git will report the error with its
 usual diagnostic.
 
-### File diffs always compared against HEAD
+### File diffs compared against the index, HEAD, or working tree
 
-When a file is specified without an explicit commit, the diff is run as
-`git diff HEAD -- <path>`. This shows the total change to the file since the
-last commit, combining staged and unstaged changes into one view. This matches
-the most common intent ("what have I changed in this file?") and avoids
-confusion between `git diff` (unstaged only) and `git diff --cached` (staged
-only).
+When a file is specified without an explicit commit, the comparison base
+follows the same rule as the no-argument case: unstaged changes by default,
+staged changes with `--staged`, and all changes (`git diff HEAD -- <path>`)
+with `--all`. This keeps file diffs consistent with whole-tree diffs and lets
+the user choose precisely which changes to inspect.
 
 ### File before commit in resolution priority
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -4,15 +4,19 @@ use crate::core::repo::{self, Target, TargetKind};
 use crate::git;
 
 /// Show a diff using short IDs (like `git diff`).
-pub fn run(args: Vec<String>) -> Result<()> {
+///
+/// By default shows unstaged changes (working tree vs index), like `git diff`.
+/// `--staged` shows staged changes (index vs HEAD); `--all` shows everything
+/// (working tree vs HEAD).
+pub fn run(args: Vec<String>, staged: bool, all: bool) -> Result<()> {
     let repo = repo::open_repo()?;
     let workdir = repo::require_workdir(&repo, "diff")?;
 
-    if args.is_empty() {
-        return git::run_git_interactive(workdir, &["diff"]);
+    let mut git_args: Vec<String> = vec!["diff".to_string()];
+    if staged {
+        git_args.push("--staged".to_string());
     }
 
-    let mut git_args: Vec<String> = vec!["diff".to_string()];
     let mut file_paths: Vec<String> = Vec::new();
     let mut has_commits = false;
 
@@ -37,11 +41,13 @@ pub fn run(args: Vec<String>) -> Result<()> {
         }
     }
 
-    // File diffs are always shown against HEAD so staged changes are included.
+    // With `--all` and no explicit commit, diff the working tree against HEAD so
+    // both staged and unstaged changes are shown in a single view.
+    if all && !has_commits {
+        git_args.push("HEAD".to_string());
+    }
+
     if !file_paths.is_empty() {
-        if !has_commits {
-            git_args.push("HEAD".to_string());
-        }
         git_args.push("--".to_string());
         git_args.extend(file_paths);
     }

--- a/src/diff_test.rs
+++ b/src/diff_test.rs
@@ -11,8 +11,28 @@ fn diff_no_args() {
     let test_repo = TestRepo::new();
     test_repo.commit("Initial commit", "file.txt");
 
-    let result = test_repo.in_dir(|| super::run(vec![]));
+    let result = test_repo.in_dir(|| super::run(vec![], false, false));
     assert!(result.is_ok(), "diff with no args should succeed");
+}
+
+#[test]
+fn diff_staged() {
+    no_pager();
+    let test_repo = TestRepo::new();
+    test_repo.commit("Initial commit", "file.txt");
+
+    let result = test_repo.in_dir(|| super::run(vec![], true, false));
+    assert!(result.is_ok(), "diff --staged should succeed");
+}
+
+#[test]
+fn diff_all() {
+    no_pager();
+    let test_repo = TestRepo::new();
+    test_repo.commit("Initial commit", "file.txt");
+
+    let result = test_repo.in_dir(|| super::run(vec![], false, true));
+    assert!(result.is_ok(), "diff --all should succeed");
 }
 
 #[test]
@@ -21,7 +41,7 @@ fn diff_commit_by_hash() {
     let test_repo = TestRepo::new();
     let oid = test_repo.commit("Test commit", "file.txt");
 
-    let result = test_repo.in_dir(|| super::run(vec![oid.to_string()]));
+    let result = test_repo.in_dir(|| super::run(vec![oid.to_string()], false, false));
     assert!(result.is_ok(), "diff with commit hash should succeed");
 }
 
@@ -33,7 +53,7 @@ fn diff_commit_range() {
     let oid2 = test_repo.commit("Second commit", "file2.txt");
 
     let range = format!("{}..{}", oid1, oid2);
-    let result = test_repo.in_dir(|| super::run(vec![range]));
+    let result = test_repo.in_dir(|| super::run(vec![range], false, false));
     assert!(result.is_ok(), "diff with commit range should succeed");
 }
 
@@ -41,6 +61,6 @@ fn diff_commit_range() {
 fn diff_invalid_target_fails() {
     let test_repo = TestRepo::new();
 
-    let result = test_repo.in_dir(|| super::run(vec!["nonexistent_xyz".to_string()]));
+    let result = test_repo.in_dir(|| super::run(vec!["nonexistent_xyz".to_string()], false, false));
     assert!(result.is_err(), "diff with invalid target should fail");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,6 +260,12 @@ enum Command {
     Diff {
         /// Files, commits, or commit ranges (short IDs supported, e.g. `ma`, `d0`, `d0..3a`)
         args: Vec<String>,
+        /// Show staged changes (index vs HEAD)
+        #[arg(long = "staged", visible_alias = "cached", conflicts_with = "all")]
+        staged: bool,
+        /// Show all changes, both staged and unstaged (working tree vs HEAD)
+        #[arg(short = 'a', long = "all")]
+        all: bool,
     },
     /// Show the latest command trace
     Trace,
@@ -431,7 +437,7 @@ fn main() {
         Some(Command::Drop { target, yes }) => drop::run(target, yes),
         Some(Command::Absorb { dry_run, files }) => absorb::run(dry_run, files),
         Some(Command::Show { target }) => show::run(target),
-        Some(Command::Diff { args }) => diff::run(args),
+        Some(Command::Diff { args, staged, all }) => diff::run(args, staged, all),
         Some(Command::Split {
             target,
             message,


### PR DESCRIPTION
Mirror git diff semantics: show unstaged changes by default, --staged
for staged changes (index vs HEAD), and --all for everything (working
tree vs HEAD).
The flags also apply to file-targeted diffs and are mutually exclusive.