### PR TITLE
feat(update): add loom.pruneGoneBranches config to auto-remove gone-upstream branches

### DIFF
--- a/docs/src/commands/update.md
+++ b/docs/src/commands/update.md
@@ -16,6 +16,12 @@ git loom update [-y]
 |--------|-------------|
 | `-y, --yes` | Skip confirmation prompt when removing branches with a gone upstream |
 
+### Configuration
+
+| Config | Description |
+|--------|-------------|
+| `loom.pruneGoneBranches` | When `true`, always remove branches with a gone upstream without prompting (same as `--yes`). Set with `git config loom.pruneGoneBranches true`. |
+
 ## What It Does
 
 ### Fetch
@@ -100,6 +106,8 @@ git loom update -y
 # ✓ Removed branch `old-feature`
 # ✓ Removed branch `closed-pr`
 ```
+
+The same behavior can be made permanent with `git config loom.pruneGoneBranches true`.
 
 ### Gone branch with unmerged commits
 

--- a/specs/010-update.md
+++ b/specs/010-update.md
@@ -39,6 +39,11 @@ git-loom update [--yes]
 
 - `--yes` / `-y`: Skip the confirmation prompt when removing branches with gone upstreams.
 
+**Configuration:**
+
+- `loom.pruneGoneBranches` (boolean): When `true`, gone-upstream branches are
+  removed without prompting, as if `--yes` had been passed. Defaults to `false`.
+
 ## What Happens
 
 ### Normal Update
@@ -61,7 +66,8 @@ git-loom update [--yes]
    initialized and updated recursively.
 6. **Gone upstream cleanup**: Any local branches whose configured upstream
    tracking branch no longer exists (pruned in step 2) are listed and the user
-   is prompted once to remove them. Use `--yes` to skip the prompt. Each branch
+   is prompted once to remove them. Use `--yes`, or set
+   `loom.pruneGoneBranches` to `true` in git config, to skip the prompt. Each branch
    that is successfully deleted prints a success message. If a branch cannot be
    deleted because it contains unmerged local commits, a warning is printed
    instead: `"Skipped branch '<name>' — it has unmerged local commits. Use 'git branch -D <name>' to force-delete."` — the remaining branches are still

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -120,6 +120,16 @@ pub fn hide_branch_pattern(repo: &Repository) -> Option<String> {
         .ok()
 }
 
+/// Read git config `loom.pruneGoneBranches`. When `true`, `loom update`
+/// removes local branches whose upstream was pruned without prompting.
+/// Returns `false` if the key is unset or not a boolean.
+pub fn prune_gone_branches(repo: &Repository) -> bool {
+    repo.config()
+        .ok()
+        .and_then(|config| config.get_bool("loom.pruneGoneBranches").ok())
+        .unwrap_or(false)
+}
+
 /// Extract the local branch name from a remote tracking ref.
 ///
 /// e.g. `"origin/main"` → `"main"`, `"origin/feat/foo"` → `"feat/foo"`.

--- a/src/update.rs
+++ b/src/update.rs
@@ -198,6 +198,7 @@ fn post_update(workdir: &Path, repo: &git2::Repository, ctx: &UpdateContext) -> 
         }
         msg::warn(&warn_msg);
         let confirmed = ctx.skip_confirm
+            || repo::prune_gone_branches(repo)
             || msg::confirm(if gone.len() == 1 {
                 "Remove it?"
             } else {

--- a/src/update_test.rs
+++ b/src/update_test.rs
@@ -241,6 +241,58 @@ fn update_preserves_merge_topology() {
 }
 
 #[test]
+fn update_removes_gone_upstream_branches_via_config() {
+    let test_repo = TestRepo::new_with_remote();
+    let remote_path = test_repo.remote_path().unwrap();
+
+    // Enable auto-removal via git config instead of the --yes flag
+    test_repo
+        .repo
+        .config()
+        .unwrap()
+        .set_bool("loom.pruneGoneBranches", true)
+        .unwrap();
+
+    // Create feature-x on the remote and fetch it so origin/feature-x exists locally
+    {
+        let remote_repo = Repository::open_bare(&remote_path).unwrap();
+        let remote_head = remote_repo
+            .find_branch("main", BranchType::Local)
+            .unwrap()
+            .get()
+            .target()
+            .unwrap();
+        let commit = remote_repo.find_commit(remote_head).unwrap();
+        remote_repo.branch("feature-x", &commit, false).unwrap();
+    }
+    test_repo
+        .repo
+        .find_remote("origin")
+        .unwrap()
+        .fetch(&["feature-x"], None, None)
+        .unwrap();
+    test_repo.create_branch_tracking("feature-x", "origin/feature-x");
+
+    // Delete feature-x from the remote (simulates upstream deletion)
+    {
+        let remote_repo = Repository::open_bare(&remote_path).unwrap();
+        let mut branch = remote_repo
+            .find_branch("feature-x", BranchType::Local)
+            .unwrap();
+        branch.delete().unwrap();
+    }
+
+    // Run update WITHOUT --yes; the config setting should skip the prompt
+    let result = test_repo.in_dir(|| super::run(false));
+    assert!(result.is_ok(), "update failed: {:?}", result.err());
+
+    assert!(
+        !test_repo.branch_exists("feature-x"),
+        "feature-x should be removed after update (loom.pruneGoneBranches = true)"
+    );
+}
+
+#[test]
 fn update_removes_branches_with_gone_upstream() {
     let test_repo = TestRepo::new_with_remote();
     let remote_path = test_repo.remote_path().unwrap();


### PR DESCRIPTION
When set to true, gone-upstream branches are removed without prompting,
as if --yes had been passed to loom update.