### PR TITLE
feat(show): default to HEAD when no target given

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -252,8 +252,8 @@ enum Command {
     /// Show the diff and metadata for a commit (like `git show`)
     #[command(visible_alias = "sh")]
     Show {
-        /// Commit hash, branch name, or short ID
-        target: String,
+        /// Commit hash, branch name, or short ID (defaults to the last commit on the current branch)
+        target: Option<String>,
     },
     /// Show a diff using short IDs (like `git diff`)
     #[command(visible_alias = "di")]

--- a/src/show.rs
+++ b/src/show.rs
@@ -4,18 +4,26 @@ use crate::core::repo::{self, Target};
 use crate::git;
 
 /// Show the diff and metadata for a commit (like `git show`), using short IDs.
-pub fn run(target: String) -> Result<()> {
+///
+/// With no target, shows the last commit on the current branch (like `git show`).
+pub fn run(target: Option<String>) -> Result<()> {
     let repo = repo::open_repo()?;
-    let resolved = repo::resolve_arg(
-        &repo,
-        &target,
-        &[repo::TargetKind::Commit, repo::TargetKind::Branch],
-    )?;
 
-    let git_ref = match resolved {
-        Target::Commit(hash) => hash,
-        Target::Branch(name) => name,
-        _ => unreachable!(),
+    let git_ref = match target {
+        None => "HEAD".to_string(),
+        Some(target) => {
+            let resolved = repo::resolve_arg(
+                &repo,
+                &target,
+                &[repo::TargetKind::Commit, repo::TargetKind::Branch],
+            )?;
+
+            match resolved {
+                Target::Commit(hash) => hash,
+                Target::Branch(name) => name,
+                _ => unreachable!(),
+            }
+        }
     };
 
     let workdir = repo::require_workdir(&repo, "show")?;

--- a/src/show_test.rs
+++ b/src/show_test.rs
@@ -13,10 +13,23 @@ fn show_commit_by_hash() {
     let test_repo = TestRepo::new();
     let oid = test_repo.commit("Test commit", "file.txt");
 
-    let result = test_repo.in_dir(|| super::run(oid.to_string()));
+    let result = test_repo.in_dir(|| super::run(Some(oid.to_string())));
     assert!(
         result.is_ok(),
         "show should succeed for a valid commit hash"
+    );
+}
+
+#[test]
+fn show_no_target_uses_head() {
+    no_pager();
+    let test_repo = TestRepo::new();
+    test_repo.commit("On main", "file.txt");
+
+    let result = test_repo.in_dir(|| super::run(None));
+    assert!(
+        result.is_ok(),
+        "show with no target should show the last commit"
     );
 }
 
@@ -29,7 +42,7 @@ fn show_branch_tip() {
     let head = test_repo.repo.head().unwrap();
     let branch_name = head.shorthand().unwrap().to_string();
 
-    let result = test_repo.in_dir(|| super::run(branch_name.clone()));
+    let result = test_repo.in_dir(|| super::run(Some(branch_name.clone())));
     assert!(result.is_ok(), "show should succeed for a branch name");
 }
 
@@ -37,6 +50,6 @@ fn show_branch_tip() {
 fn show_invalid_target_fails() {
     let test_repo = TestRepo::new();
 
-    let result = test_repo.in_dir(|| super::run("nonexistent_target_xyz".to_string()));
+    let result = test_repo.in_dir(|| super::run(Some("nonexistent_target_xyz".to_string())));
     assert!(result.is_err(), "show should fail for invalid target");
 }


### PR DESCRIPTION
`loom show` without arguments now shows the last commit on the
current branch, matching `git show` behavior, instead of erroring.