### PR TITLE
feat(pull): show whether anything was pulled

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -76,6 +76,17 @@ pub fn run_git_stdout(workdir: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
+/// Run a git command and return its combined stdout+stderr, trimmed.
+/// Useful for commands (like `fetch`) that print their summary to stderr, so a
+/// caller can show git's output after a spinner instead of streaming it live.
+/// On failure, returns an error with the command name; stderr is still traced.
+pub fn run_git_combined(workdir: &Path, args: &[&str]) -> Result<String> {
+    let output = run_git_captured(workdir, args)?;
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    Ok(combined.trim().to_string())
+}
+
 /// Check that the installed Git version meets the minimum requirement.
 /// Returns an error with an actionable message if the version is too old.
 pub fn check_git_version() -> Result<()> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -48,15 +48,26 @@ pub fn run(skip_confirm: bool) -> Result<()> {
         .context("Upstream branch name is not valid UTF-8")?
         .to_string();
 
-    // Fetch with tags, force-update, and prune deleted remote branches
+    // Fetch with tags, force-update, and prune deleted remote branches.
+    // The spinner reassures the user that work is happening (fetches can be slow);
+    // afterwards we print git's own summary so they can tell whether anything was
+    // actually pulled (e.g. `a309e49..7b3c4c1 main -> origin/main`). `--no-progress`
+    // drops the transfer noise (`remote: ...`, `Receiving objects`) so the captured
+    // output is just the clean ref-update summary.
     let spinner = msg::spinner();
     spinner.start("Fetching latest changes...");
 
-    let result = git::run_git(&workdir, &["fetch", "--tags", "--force", "--prune"]);
+    let result = git::run_git_combined(
+        &workdir,
+        &["fetch", "--no-progress", "--tags", "--force", "--prune"],
+    );
 
     match result {
-        Ok(()) => {
+        Ok(summary) => {
             spinner.stop("Fetched latest changes");
+            if !summary.is_empty() {
+                println!("{}", summary);
+            }
         }
         Err(e) => {
             spinner.error("Fetch failed");


### PR DESCRIPTION
Before:
✓ Fetched latest changes
✓ Rebased onto upstream
✓ Updated submodules
✓ Updated branch wip-stack with origin/master (f7264ed Enforce commit message requirements)

After:
Total 35 (delta 16), reused 30 (delta 16)
From ssh://codereview.kdab.com:29418/kdab/KDABViewer
   389626f55..f7264ed16  master     -> origin/master
✓ Fetched latest changes
✓ Rebased onto upstream
✓ Updated submodules
✓ Updated branch wip-stack with origin/master (f7264ed Enforce commit message requirements)

(plus any new or deleted branches)

I need to know that new changes / branches have been pulled.
(to know if I need to rebuild; to look at what the cat brought in; etc.)