### PR TITLE
fix(fold): capture git rebase --continue output instead of leaking it

### DIFF
--- a/src/git/git_rebase.rs
+++ b/src/git/git_rebase.rs
@@ -19,12 +19,28 @@ pub enum RebaseOutcome {
 /// initial rebase in `weave::run_rebase`).
 pub fn continue_rebase(workdir: &Path) -> Result<RebaseOutcome> {
     use std::process::Command;
-    let status = Command::new("git")
+    use std::time::Instant;
+
+    use crate::trace as loom_trace;
+
+    let start = Instant::now();
+    let output = Command::new("git")
         .current_dir(workdir)
         .args(["rebase", "--continue"])
         .env("GIT_EDITOR", "true")
-        .status()?;
-    if status.success() {
+        .output()?;
+
+    let duration_ms = start.elapsed().as_millis();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    loom_trace::log_command(
+        "git",
+        "rebase --continue",
+        duration_ms,
+        output.status.success(),
+        &stderr,
+    );
+
+    if output.status.success() {
         Ok(RebaseOutcome::Completed)
     } else {
         Ok(RebaseOutcome::Conflicted)

--- a/src/git/git_rebase.rs
+++ b/src/git/git_rebase.rs
@@ -120,3 +120,7 @@ pub fn continue_rebase_or_abort(workdir: &Path) -> Result<()> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "git_rebase_test.rs"]
+mod tests;

--- a/src/git/git_rebase_test.rs
+++ b/src/git/git_rebase_test.rs
@@ -1,0 +1,34 @@
+use crate::core::test_helpers::TestRepo;
+use crate::core::weave;
+use crate::trace;
+
+/// Regression (#159): `continue_rebase` must capture git's output and route it
+/// to the trace, instead of running with inherited stdio and leaking git's
+/// "Successfully rebased" / "Updated refs" messages to the terminal. Before the
+/// fix it logged nothing at all, so asserting the trace records the step proves
+/// the output is now captured (you can only log stderr you captured).
+#[test]
+fn continue_rebase_captures_output_to_trace() {
+    let test_repo = TestRepo::new();
+    let c1 = test_repo.commit("first", "a.txt");
+    test_repo.commit("second", "b.txt");
+    let workdir = test_repo.workdir();
+
+    // Pause a rebase at the first commit so there is something to continue.
+    weave::start_edit_rebase(&test_repo.repo, &workdir, c1).unwrap();
+
+    // The trace logger is thread-local and cargo reuses threads across tests;
+    // clear any logger a prior test leaked so our init reliably takes effect.
+    let _ = trace::finalize();
+    let git_dir = test_repo.repo.path().to_path_buf();
+    trace::init(&git_dir, "git loom fold");
+    let outcome = super::continue_rebase(&workdir).unwrap();
+    let log_path = trace::finalize().expect("trace should have recorded an entry");
+
+    assert!(matches!(outcome, super::RebaseOutcome::Completed));
+    let content = std::fs::read_to_string(&log_path).unwrap();
+    assert!(
+        content.contains("[git] rebase --continue"),
+        "trace should record the continue step, got:\n{content}"
+    );
+}


### PR DESCRIPTION
fix(fold): capture git rebase --continue output instead of leaking it

continue_rebase ran with inherited stdio, so git's own "Successfully
rebased" / "Updated the following refs" messages printed to the
terminal. Multi-phase folds (e.g. moving a file between commits) called
it twice, doubling the noise on top of loom's own success line. Capture
the output and route stderr to the trace, matching run_rebase.

Fixes #159

Claude-Session: https://claude.ai/code/session_01GhTVonYVZ24ZMgNZQLVyAU

---

test(fold): assert continue_rebase records output to trace

Regression test for #159: a paused rebase is continued and the trace log
must contain the 'rebase --continue' step, which only happens if the
command's output is captured rather than inherited.

Claude-Session: https://claude.ai/code/session_01GhTVonYVZ24ZMgNZQLVyAU