### PR TITLE
fix(branch): run check-ref-format in a workdir to fix flaky validation

### DIFF
--- a/src/branch/new.rs
+++ b/src/branch/new.rs
@@ -38,7 +38,7 @@ pub fn run(name: Option<String>, target: Option<String>) -> Result<()> {
         bail!("Branch name cannot be empty");
     }
 
-    git::branch_validate_name(&name)?;
+    git::branch_validate_name(workdir, &name)?;
 
     repo::ensure_branch_not_exists(&repo, &name)?;
 

--- a/src/branch/new_test.rs
+++ b/src/branch/new_test.rs
@@ -41,13 +41,15 @@ fn branch_ownership_splits_commits() {
 
 #[test]
 fn branch_invalid_name_fails() {
-    let result = crate::git::branch_validate_name("my..branch");
+    let workdir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let result = crate::git::branch_validate_name(workdir, "my..branch");
     assert!(result.is_err(), "double dots should be invalid");
 
-    let result = crate::git::branch_validate_name("has space");
+    let result = crate::git::branch_validate_name(workdir, "has space");
     assert!(result.is_err(), "spaces should be invalid");
 
-    let result = crate::git::branch_validate_name("valid-name");
+    let result = crate::git::branch_validate_name(workdir, "valid-name");
     assert!(result.is_ok(), "valid name should pass");
 }
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -283,7 +283,7 @@ fn resolve_explicit_branch(
             if name.is_empty() {
                 bail!("Branch name cannot be empty");
             }
-            git::branch_validate_name(&name)?;
+            git::branch_validate_name(workdir, &name)?;
 
             if repo.find_branch(&name, git2::BranchType::Local).is_ok() {
                 bail!(
@@ -324,7 +324,7 @@ fn pick_branch(
 
     // If user typed a name that isn't an existing woven branch, create it
     if !branch_names.contains(&name) {
-        git::branch_validate_name(&name)?;
+        git::branch_validate_name(workdir, &name)?;
         repo::ensure_branch_not_exists(repo, &name)?;
         create_branch_at_merge_base(workdir, &name, info.upstream.merge_base_oid)?;
         return Ok((name, true));

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -165,7 +165,7 @@ fn run_create(repo: &Repository, args: &[String]) -> Result<()> {
     // Order oldest-first so the commits land on the branch in history order.
     let commit_hashes = sort_commits_oldest_first(repo, commit_hashes)?;
 
-    git::branch_validate_name(branch_name)?;
+    git::branch_validate_name(workdir, branch_name)?;
 
     // If the branch already exists, warn and fall through to a normal move.
     let branch_exists = repo

--- a/src/git/git_branch.rs
+++ b/src/git/git_branch.rs
@@ -6,8 +6,12 @@ use anyhow::{Context, Result, bail};
 use super::run_git;
 
 /// Validate a branch name using `git check-ref-format`.
-pub fn branch_validate_name(name: &str) -> Result<()> {
+///
+/// Runs in `workdir` so it does not depend on the process-global cwd (which
+/// git reads even for `--branch`; a deleted cwd makes it fail).
+pub fn branch_validate_name(workdir: &Path, name: &str) -> Result<()> {
     let output = Command::new("git")
+        .current_dir(workdir)
         .args(["check-ref-format", "--branch", name])
         .output()
         .context("Failed to run git check-ref-format")?;

--- a/src/init.rs
+++ b/src/init.rs
@@ -20,7 +20,7 @@ pub fn run(name: Option<String>) -> Result<()> {
         bail!("Branch name cannot be empty");
     }
 
-    git::branch_validate_name(&name)?;
+    git::branch_validate_name(workdir, &name)?;
 
     repo::ensure_branch_not_exists(&repo, &name)?;
 

--- a/src/reword.rs
+++ b/src/reword.rs
@@ -38,7 +38,8 @@ pub fn run(target: String, message: Option<String>) -> Result<()> {
             if new_name == name {
                 return Ok(());
             }
-            git::branch_validate_name(&new_name)?;
+            let workdir = repo::require_workdir(&repo, "reword")?;
+            git::branch_validate_name(workdir, &new_name)?;
             reword_branch(&repo, &name, &new_name)
         }
         _ => unreachable!(),


### PR DESCRIPTION
branch_validate_name spawned 'git check-ref-format' without setting the
child's cwd, so it inherited the process-global cwd. Git reads cwd even
for --branch, so when a parallel test had pointed the process at a temp
dir that was later deleted, validating a valid name failed with exit 128
(flaky branch_invalid_name_fails). Pass the caller's workdir through and
set current_dir, matching the other git wrappers.