### PR TITLE
fix(branch): merge local branches whose name contains a slash

### DIFF
--- a/src/branch/merge.rs
+++ b/src/branch/merge.rs
@@ -28,16 +28,16 @@ pub fn run(branch: Option<String>, all: bool) -> Result<()> {
         None => pick_branch(&repo, &info, all)?,
     };
 
-    // If this is a remote branch (contains '/'), create a local tracking branch
-    let local_name = if branch_name.contains('/') {
+    // Remote branches need a local tracking branch before they can be merged.
+    let local_name = if repo.find_branch(&branch_name, BranchType::Local).is_ok() {
+        branch_name.clone()
+    } else {
         let local = repo::upstream_local_branch(&branch_name);
         git::branch_create(workdir, &local, &branch_name)?;
         // Set up tracking
         let mut local_branch = repo.find_branch(&local, BranchType::Local)?;
         local_branch.set_upstream(Some(&branch_name))?;
         local
-    } else {
-        branch_name.clone()
     };
 
     // Merge the branch into integration (--no-ff) so it appears in the topology

--- a/src/branch/merge_test.rs
+++ b/src/branch/merge_test.rs
@@ -40,6 +40,38 @@ fn merge_weaves_existing_branch() {
     );
 }
 
+/// A local branch whose name contains '/' must be merged as-is, not mistaken
+/// for a remote branch and stripped down to a duplicate ref.
+#[test]
+fn merge_local_branch_with_slash_keeps_full_name() {
+    let test_repo = TestRepo::new_with_remote();
+
+    test_repo.commit("B1", "b1.txt");
+
+    let base_oid = test_repo.find_remote_branch_target("origin/main");
+    test_repo.create_branch_at("wip/dfaure/feature-a", &base_oid.to_string());
+
+    test_repo.switch_branch("wip/dfaure/feature-a");
+    test_repo.commit("A1", "a1.txt");
+    test_repo.switch_branch("integration");
+
+    test_repo
+        .in_dir(|| super::merge::run(Some("wip/dfaure/feature-a".to_string()), false))
+        .unwrap();
+
+    let info = repo::gather_repo_info(&test_repo.repo, false, 1).unwrap();
+    let branch_names: Vec<&str> = info.branches.iter().map(|b| b.name.as_str()).collect();
+    assert!(
+        branch_names.contains(&"wip/dfaure/feature-a"),
+        "the branch passed in must be the one woven, got: {:?}",
+        branch_names
+    );
+    assert!(
+        !test_repo.branch_exists("dfaure/feature-a"),
+        "no duplicate ref with the first path component stripped may be created"
+    );
+}
+
 /// Merging an already-woven branch should error.
 #[test]
 fn merge_already_woven_errors() {


### PR DESCRIPTION
'contains(/)' was used to detect a remote branch, so a local branch like
wip/foo was mistaken for one: the first path component got stripped, a
duplicate ref was created at the same commit, and that duplicate was
merged instead. Look the branch up as local first instead of guessing.