### PR TITLE
feat(paths): accept absolute file paths like git

### DIFF
--- a/specs/002-shortid.md
+++ b/specs/002-shortid.md
@@ -271,10 +271,12 @@ All commands resolve user-provided arguments through `git::resolve_arg(repo, arg
 The `accept` parameter is a `&[TargetKind]` slice specifying which kinds of targets the
 command accepts and in what priority order. Resolution strategies are only attempted for
 the listed kinds. Merge commits are automatically rejected when resolving `Commit` targets.
-CWD-relative path conversion is handled internally for `File` targets.
+Path conversion to repo-relative form is handled internally for `File` targets.
 
 Available `TargetKind` values:
-- `File` — a working-tree file path (CWD-relative → repo-relative conversion applied)
+- `File` — a working-tree file path, either CWD-relative or absolute (converted
+  to repo-relative). An absolute path outside the repository is an error:
+  `'<path>' is outside repository`.
 - `Branch` — a local branch name
 - `Commit` — a non-merge commit (hash, `HEAD`, etc.; branch names are excluded)
 - `CommitFile` — a commit-file reference (e.g. `02:0`)

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -229,12 +229,17 @@ fn reject_merge_commit(repo: &Repository, oid: git2::Oid) -> Result<()> {
     Ok(())
 }
 
-/// Try to resolve `arg` as a file path (CWD-relative → repo-relative).
+/// Try to resolve `arg` as a file path (absolute or CWD-relative → repo-relative).
 fn try_resolve_file(repo: &Repository, arg: &str) -> Result<Option<Target>> {
-    let repo_path = cwd_to_repo_path(repo, arg).unwrap_or_else(|_| arg.to_string());
     let workdir = match repo.workdir() {
         Some(w) => w,
         None => return Ok(None),
+    };
+    let repo_path = if Path::new(arg).is_absolute() {
+        // Like git, an absolute path outside the repo is an error, not a miss.
+        abs_to_repo_path(workdir, arg)?
+    } else {
+        cwd_to_repo_path(repo, arg).unwrap_or_else(|_| arg.to_string())
     };
     let full_path = workdir.join(&repo_path);
     if full_path.exists() {
@@ -343,6 +348,42 @@ fn try_resolve_shortid(
         }
     }
     Ok(None)
+}
+
+/// Convert a user-supplied path — absolute or CWD-relative — to a repo-relative
+/// path, the way git accepts either form.
+pub fn to_repo_path(repo: &Repository, arg: &str) -> Result<String> {
+    if Path::new(arg).is_absolute() {
+        let workdir = repo
+            .workdir()
+            .context("Repository has no working directory")?;
+        abs_to_repo_path(workdir, arg)
+    } else {
+        cwd_to_repo_path(repo, arg)
+    }
+}
+
+/// Convert an absolute path to a repo-relative path.
+///
+/// Errors when the path lies outside the repository, like git does.
+fn abs_to_repo_path(workdir: &Path, arg: &str) -> Result<String> {
+    // Canonicalize both sides so symlinked repo paths still match.  It fails on
+    // paths that no longer exist (deleted files), so fall back to the path itself.
+    let workdir_canonical =
+        std::fs::canonicalize(workdir).unwrap_or_else(|_| workdir.to_path_buf());
+    let path = Path::new(arg);
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+    let rel = canonical
+        .strip_prefix(&workdir_canonical)
+        .map_err(|_| anyhow::anyhow!("'{}' is outside repository", arg))?;
+    let s = rel
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    // The repo root itself means "everything"; "." is git's spelling for that.
+    Ok(if s.is_empty() { ".".to_string() } else { s })
 }
 
 /// Convert a CWD-relative path to a repo-relative path.

--- a/src/core/repo_test.rs
+++ b/src/core/repo_test.rs
@@ -382,6 +382,55 @@ fn resolve_arg_file_cwd_relative() {
 }
 
 #[test]
+fn resolve_arg_file_absolute_path() {
+    let test_repo = TestRepo::new_with_remote();
+    let sub_dir = test_repo.workdir().join("sub");
+    std::fs::create_dir_all(&sub_dir).unwrap();
+    let abs = sub_dir.join("deep.txt");
+    std::fs::write(&abs, "content").unwrap();
+    let arg = abs.to_string_lossy().into_owned();
+    test_repo.in_dir(|| {
+        let result = repo::resolve_arg(&test_repo.repo, &arg, &[TargetKind::File]).unwrap();
+        assert_eq!(result, Target::File("sub/deep.txt".to_string()));
+    });
+}
+
+#[test]
+fn resolve_arg_file_absolute_path_from_subdir() {
+    let test_repo = TestRepo::new_with_remote();
+    let sub_dir = test_repo.workdir().join("sub");
+    std::fs::create_dir_all(&sub_dir).unwrap();
+    test_repo.write_file("top.txt", "content");
+    let arg = test_repo
+        .workdir()
+        .join("top.txt")
+        .to_string_lossy()
+        .into_owned();
+    // CWD is a subdir, so the prefix must not be prepended to an absolute path.
+    test_repo.in_dir_path(&sub_dir, || {
+        let result = repo::resolve_arg(&test_repo.repo, &arg, &[TargetKind::File]).unwrap();
+        assert_eq!(result, Target::File("top.txt".to_string()));
+    });
+}
+
+#[test]
+fn resolve_arg_file_absolute_outside_repo_errors() {
+    let test_repo = TestRepo::new_with_remote();
+    let outside = tempfile::tempdir().unwrap();
+    let abs = outside.path().join("stranger.txt");
+    std::fs::write(&abs, "content").unwrap();
+    let arg = abs.to_string_lossy().into_owned();
+    test_repo.in_dir(|| {
+        let result = repo::resolve_arg(&test_repo.repo, &arg, &[TargetKind::File]);
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("outside repository"),
+            "error should say the path is outside the repo: {msg}"
+        );
+    });
+}
+
+#[test]
 fn resolve_arg_file_not_found_errors() {
     let test_repo = TestRepo::new_with_remote();
     test_repo.in_dir(|| {

--- a/src/split.rs
+++ b/src/split.rs
@@ -57,6 +57,12 @@ fn split_commit(
 
     let original_msg = commit.message().unwrap_or("").trim().to_string();
 
+    // The commit's file list is repo-relative, so the given paths must be too.
+    let files: Vec<String> = files
+        .iter()
+        .map(|f| repo::to_repo_path(repo, f))
+        .collect::<Result<_>>()?;
+
     if patch {
         let oid_str = commit_oid.to_string();
         let selections = staging::run_commit_hunk_picker(workdir, &oid_str, &files, theme)?

--- a/src/split_test.rs
+++ b/src/split_test.rs
@@ -39,6 +39,41 @@ fn split_head_commit() {
     );
 }
 
+#[test]
+fn split_head_commit_with_absolute_path() {
+    let test_repo = TestRepo::new();
+    test_repo.commit("Add files", "file1.txt");
+
+    let target_oid = test_repo.commit_multi(
+        &[("file_a.txt", "content a"), ("file_b.txt", "content b")],
+        "Two files commit",
+    );
+
+    let abs = test_repo
+        .workdir()
+        .join("file_a.txt")
+        .to_string_lossy()
+        .into_owned();
+
+    let result = test_repo.in_dir(|| {
+        super::split_commit_with_selection(
+            &test_repo.repo,
+            &target_oid.to_string(),
+            vec![abs.clone()],
+            "First part".to_string(),
+        )
+    });
+
+    assert!(
+        result.is_ok(),
+        "split with absolute path failed: {result:?}"
+    );
+    assert_eq!(
+        test_repo.commit_file_paths(test_repo.get_oid(1)),
+        vec!["file_a.txt"]
+    );
+}
+
 // ── Non-HEAD split tests ──────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
File arguments can now be given as absolute paths, not just CWD-relative
ones. An absolute path outside the repository is an error, matching git.