### PR TITLE
fix(update): fetch the push remote too, so gone branches are detected

### DIFF
--- a/docs/src/commands/update.md
+++ b/docs/src/commands/update.md
@@ -28,6 +28,8 @@ git loom update [-y]
 
 Runs `git fetch --tags --force --prune` against the tracked remote. Force-updates moved tags and prunes deleted remote branches from local tracking refs.
 
+In a fork workflow, where `loom push` sends feature branches to another remote (see [push](push.md)), that remote is fetched too with `git fetch --prune <remote>` — otherwise its tracking refs go stale and branches deleted on the fork are never seen as gone. Tags are only fetched from the tracked remote. If the fork is unreachable, loom warns and continues with the update.
+
 ### Upstream Commit Filtering
 
 Before rebasing, loom scans every feature-branch commit against the new upstream and drops any that are already present. Two strategies are applied:

--- a/specs/010-update.md
+++ b/specs/010-update.md
@@ -15,7 +15,8 @@ After initializing an integration branch with `git loom init`, the upstream
 remote will continue to receive new commits. The update command brings those
 changes into the local integration branch in a single step:
 
-- **Fetch** all upstream changes, including tags, and prune deleted remote branches
+- **Fetch** all upstream changes, including tags, and prune deleted remote
+  branches — on the push remote too, when it differs (fork workflow)
 - **Rebase** local commits onto the updated upstream, keeping feature branches
   on the correct side of the topology
 - **Filter** commits already merged or cherry-picked upstream, preventing
@@ -52,8 +53,10 @@ git-loom update [--yes]
 
 1. **Validation**: HEAD must be on a branch (not detached), the branch must have
    an upstream tracking ref, and the repository must have a working tree.
-2. **Fetch**: All upstream changes are fetched, including tags. Moved tags
-   are force-updated. Deleted remote branches are pruned locally.
+2. **Fetch**: All upstream changes are fetched from the remote the integration
+   branch tracks, including tags. Moved tags are force-updated. Deleted remote
+   branches are pruned locally. When the push remote differs from that remote
+   (fork workflow), it is fetched and pruned as well — branches only, no tags.
 3. **Upstream commit filtering**: Before rebasing, any feature-branch commits
    already present in the new upstream are removed from the rebase todo. This
    uses two detection strategies (see "Upstream Commit Filtering" below).
@@ -306,6 +309,25 @@ The fetch step synchronizes all upstream state, not just branch commits:
   state clean
 
 This provides a complete sync rather than a minimal one.
+
+### Fetching the Push Remote
+
+In a fork workflow the feature branches live on the push remote (`loom.push-remote`,
+or the GitHub `upstream`/`origin` convention — see Spec 011), not on the remote
+the integration branch tracks. That remote is the one whose deletions matter for
+gone-upstream detection, so `update` fetches it too, with `--prune`, using the
+same resolution as `loom push`. Without it the fork's remote-tracking refs stay
+stale forever and no branch is ever reported as gone.
+
+Only the remotes loom itself uses are fetched — not `--all`, which would also hit
+read-only remotes added for cherry-picking. Single-remote setups resolve to the
+same remote and pay nothing.
+
+Tags are not fetched from the push remote: the integration remote's tags are the
+authoritative ones, and force-updating from a fork could move them backwards.
+
+A failure to fetch the push remote is a warning, not an error: the integration
+branch can still be rebased onto its own upstream.
 
 ### Automatic Working Tree Preservation
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -248,6 +248,20 @@ fn resolve_push_remote(
     }
 }
 
+/// The remote `loom push` sends feature branches to, when it differs from the
+/// remote the integration branch tracks — i.e. a fork workflow.
+///
+/// Returns `None` for the common single-remote setup, where both are the same.
+pub(crate) fn fork_push_remote(
+    repo: &Repository,
+    workdir: &Path,
+    upstream_label: &str,
+) -> Option<String> {
+    let remote_type = detect_remote_type(repo, workdir, upstream_label).ok()?;
+    let push_remote = resolve_push_remote(repo, workdir, upstream_label, &remote_type);
+    (push_remote != extract_remote_name(upstream_label)).then_some(push_remote)
+}
+
 /// Run a `git push …`, trace-log it, bail on failure, and return its stderr.
 ///
 /// stderr carries the server's `remote:` messages — GitLab MR links, Gerrit

--- a/src/update.rs
+++ b/src/update.rs
@@ -75,6 +75,8 @@ pub fn run(skip_confirm: bool) -> Result<()> {
         }
     }
 
+    fetch_push_remote(&repo, &workdir, &upstream_name);
+
     // Save rollback state before the rebase
     let ctx = UpdateContext {
         branch_name: branch_name.clone(),
@@ -144,6 +146,41 @@ pub fn run(skip_confirm: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Fetch and prune the push remote when it differs from the integration
+/// branch's remote.
+///
+/// In a fork workflow feature branches live on the push remote, which the
+/// fetch above never touches — its remote-tracking refs would stay stale
+/// forever and branches deleted on the fork would never show up as gone.
+///
+/// Only branches are pruned here: tags come from the integration remote,
+/// whose tags are the authoritative ones.
+fn fetch_push_remote(repo: &git2::Repository, workdir: &Path, upstream_name: &str) {
+    let Some(remote) = crate::push::fork_push_remote(repo, workdir, upstream_name) else {
+        return;
+    };
+
+    let spinner = msg::spinner();
+    spinner.start(&format!("Fetching `{}`...", remote));
+
+    match git::run_git_combined(workdir, &["fetch", "--no-progress", "--prune", &remote]) {
+        Ok(summary) => {
+            spinner.stop(&format!("Fetched `{}`", remote));
+            if !summary.is_empty() {
+                println!("{}", summary);
+            }
+        }
+        // An unreachable fork must not stop the update: the integration branch
+        // can still be rebased onto its own upstream.
+        Err(_) => {
+            spinner.error(&format!(
+                "Could not fetch `{}` — branches deleted there are not detected",
+                remote
+            ));
+        }
+    }
 }
 
 /// Resume an `update` operation after a conflict has been resolved.

--- a/src/update_test.rs
+++ b/src/update_test.rs
@@ -345,6 +345,50 @@ fn update_removes_branches_with_gone_upstream() {
 }
 
 #[test]
+fn update_prunes_the_push_remote_in_a_fork_workflow() {
+    let test_repo = TestRepo::new_with_remote();
+    let remote_path = test_repo.remote_path().unwrap();
+
+    // Add a fork as a second remote and make `loom push` target it
+    let fork_path = remote_path.parent().unwrap().join("fork.git");
+    Repository::init_bare(&fork_path).unwrap();
+    test_repo
+        .repo
+        .remote("personal", fork_path.to_str().unwrap())
+        .unwrap();
+    test_repo.set_config("loom.push-remote", "personal");
+
+    // Push feature-x to the fork, so it tracks personal/feature-x
+    test_repo.create_branch("feature-x");
+    let workdir = test_repo.workdir();
+    crate::git::run_git(&workdir, &["push", "-u", "personal", "feature-x"]).unwrap();
+
+    // Delete feature-x from the fork (simulates GitHub deleting a merged PR branch)
+    {
+        let fork_repo = Repository::open_bare(&fork_path).unwrap();
+        let mut branch = fork_repo
+            .find_branch("feature-x", BranchType::Local)
+            .unwrap();
+        branch.delete().unwrap();
+    }
+
+    let result = test_repo.in_dir(|| super::run(true));
+    assert!(result.is_ok(), "update failed: {:?}", result.err());
+
+    assert!(
+        test_repo
+            .repo
+            .find_reference("refs/remotes/personal/feature-x")
+            .is_err(),
+        "the stale tracking ref on the push remote should be pruned"
+    );
+    assert!(
+        !test_repo.branch_exists("feature-x"),
+        "feature-x should be removed after update (deleted on the push remote)"
+    );
+}
+
+#[test]
 fn update_keeps_branches_without_tracking_config() {
     let test_repo = TestRepo::new_with_remote();
 


### PR DESCRIPTION
In a fork workflow the feature branches live on the push remote, which the
plain `git fetch` never touches: its tracking refs stay stale, so no branch
is ever reported as gone. Fetch it with --prune when it differs from the
integration branch's remote, reusing the resolution `loom push` does.

No tags from the fork, and a failure only warns — the rebase onto upstream
still works.