### PR TITLE
sync or protect branches checked out in other worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ git-loom must never discard user data — staged changes, working tree changes, 
 2. Register the command name in `transaction::dispatch_after_continue`
 3. There is no `dispatch_after_abort` — abort is handled automatically by `Rollback::apply_abort()`
 
+**Worktree ref safety** (`git/git_worktree.rs`): the explicit `update-ref` todo lines bypass git's check against moving a branch checked out in another worktree. `weave::run_rebase` therefore refuses up front if such a worktree has local changes, and hard-resets clean ones to the rewritten tip once the rebase completes. The sync plan survives a paused rebase in `<git_dir>/loom/worktree-sync.json`, applied by `finish_worktree_syncs` (idempotent, called from every completion/abort path); a sync only fires if the branch actually moved and the worktree still matches the recorded old tip, so user changes made mid-pause are never discarded.
+
 ## Error Reporting Convention
 
 Git command failures (via `run_git`/`run_git_stdout`) log stderr to the trace only — do **not** include stderr in the `bail!` error message. The top-level error handler in `main.rs` already appends a hint to run `loom trace`. Never add stderr to user-facing error messages from git subprocess wrappers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ git-loom must never discard user data — staged changes, working tree changes, 
 2. Register the command name in `transaction::dispatch_after_continue`
 3. There is no `dispatch_after_abort` — abort is handled automatically by `Rollback::apply_abort()`
 
-**Worktree ref safety** (`git/git_worktree.rs`): the explicit `update-ref` todo lines bypass git's check against moving a branch checked out in another worktree. `weave::run_rebase` therefore refuses up front if such a worktree has local changes, and hard-resets clean ones to the rewritten tip once the rebase completes. The sync plan survives a paused rebase in `<git_dir>/loom/worktree-sync.json`, applied by `finish_worktree_syncs` (idempotent, called from every completion/abort path); a sync only fires if the branch actually moved and the worktree still matches the recorded old tip, so user changes made mid-pause are never discarded.
+**Worktree ref safety** (`git/git_worktree.rs`, spec 004): the explicit `update-ref` todo lines bypass git's check against moving a branch checked out in another worktree. `weave::run_rebase` therefore refuses up front if such a worktree has local changes, and fast-forwards clean ones to the rewritten tip once the rebase completes (`read-tree -m -u`, which refuses to overwrite untracked files). The sync plan survives a paused rebase in `<git_dir>/loom/worktree-sync.json`, applied by `finish_worktree_syncs` (idempotent, called from every completion/abort path); a sync only fires if the branch actually moved and the worktree still matches the recorded old tip, so user changes made mid-pause are never discarded.
 
 ## Error Reporting Convention
 

--- a/specs/004-weave.md
+++ b/specs/004-weave.md
@@ -155,6 +155,35 @@ Key behaviors:
   commands (e.g., `reword`, `split`, excluded `fold` paths) abort explicitly
   and leave the repository in its original state
 
+## Worktree Ref Safety
+
+The `update-ref` directives bypass git's porcelain check against moving a
+branch that is checked out in another worktree, which would desync that
+worktree: its index and files stay at the old tip, so `git status` there
+shows the old→new delta as phantom staged changes. Before executing the
+todo, every branch named in an `update-ref` directive is mapped to worktrees
+(`git worktree list --porcelain`):
+
+- Checked out in the worktree the rebase runs in: no special handling — the
+  rebase moves ref, index, and files together.
+- Checked out in another worktree that has local changes (staged or modified
+  tracked files, unmerged entries, or an operation in progress): the whole
+  operation is refused before anything is rewritten, naming the branch and
+  worktree path. Untracked files alone do not count as local changes.
+- Checked out in another clean worktree: after the rebase completes, the
+  worktree is fast-forwarded to the rewritten tip (`read-tree -m -u`), which
+  refuses — with a warning — rather than overwrite an untracked file that the
+  rewritten branch newly tracks.
+- Detached-HEAD worktrees, and worktrees whose directory is gone, are
+  unaffected.
+
+Because the rebase can pause (conflict or `edit`), the planned syncs are
+saved to `.git/loom/worktree-sync.json` and applied when the rebase machinery
+finishes, from any completion or abort path. A sync only fires if the branch
+actually moved away from the recorded old tip and the worktree still matches
+that tip, so applying after an abort is a no-op, and a worktree modified
+during the pause is left alone (with a warning) instead of being reset.
+
 ## Integration with Commands
 
 | Command | Mutations used |

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -183,6 +183,10 @@ pub fn continue_cmd(workdir: &Path, git_dir: &Path) -> Result<()> {
     // else: no rebase or merge is in progress — the user already ran
     // `git rebase --continue` manually, so move straight to dispatch.
 
+    // No-op unless the user completed the rebase manually — the loom-driven
+    // paths sync worktrees inside `continue_rebase` already.
+    git::finish_worktree_syncs(workdir);
+
     dispatch_after_continue(workdir, &state)?;
     delete(git_dir)?;
     Ok(())
@@ -204,6 +208,11 @@ pub fn abort_cmd(workdir: &Path, git_dir: &Path) -> Result<()> {
     } else if git::merge_is_in_progress(git_dir) {
         let _ = git::merge_abort(workdir);
     }
+
+    // Settle any worktree sync plan left by the interrupted rebase: a no-op
+    // cleanup if refs were restored, a real sync if the user completed the
+    // rebase manually before aborting.
+    git::finish_worktree_syncs(workdir);
 
     state.rollback.apply_abort(workdir)?;
     delete(git_dir)?;

--- a/src/core/weave.rs
+++ b/src/core/weave.rs
@@ -1173,6 +1173,15 @@ pub fn run_rebase(
 
     use crate::trace as loom_trace;
 
+    // The `update-ref` lines in the todo bypass git's check against moving a
+    // branch checked out in another worktree. Refuse dirty worktrees up front;
+    // clean ones are synced to the rewritten tips once the rebase completes.
+    let worktree_syncs =
+        git::plan_worktree_syncs(workdir, &todo_update_ref_branches(todo_content))?;
+    if !worktree_syncs.is_empty() {
+        git::save_worktree_syncs(workdir, &worktree_syncs)?;
+    }
+
     let self_exe = git::loom_exe_path()?;
 
     // Write todo content to a temp file
@@ -1265,6 +1274,8 @@ pub fn run_rebase(
                 return Ok(RebaseOutcome::Conflicted);
             }
         }
+        // The rebase never started — no refs moved, drop the sync plan.
+        git::finish_worktree_syncs(workdir);
         let stderr_msg = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!("git rebase failed: {}", stderr_msg.trim());
     }
@@ -1272,7 +1283,22 @@ pub fn run_rebase(
     // Clean up the temp file
     let _ = temp_path.close();
 
+    // Sync worktrees now unless the rebase paused at an `edit` command
+    // (then the refs move when the rebase is continued to completion).
+    git::finish_worktree_syncs(workdir);
+
     Ok(RebaseOutcome::Completed)
+}
+
+/// Branch names from `update-ref refs/heads/<name>` lines in a todo.
+///
+/// These are exactly the refs the rebase will rewrite (besides HEAD's branch,
+/// which moves together with the current worktree).
+fn todo_update_ref_branches(todo: &str) -> Vec<String> {
+    todo.lines()
+        .filter_map(|line| line.trim().strip_prefix("update-ref refs/heads/"))
+        .map(str::to_string)
+        .collect()
 }
 
 /// Returns OIDs in `base..HEAD` that have cherry-pick equivalents in `upstream`.

--- a/src/core/weave.rs
+++ b/src/core/weave.rs
@@ -1178,9 +1178,7 @@ pub fn run_rebase(
     // clean ones are synced to the rewritten tips once the rebase completes.
     let worktree_syncs =
         git::plan_worktree_syncs(workdir, &todo_update_ref_branches(todo_content))?;
-    if !worktree_syncs.is_empty() {
-        git::save_worktree_syncs(workdir, &worktree_syncs)?;
-    }
+    git::save_worktree_syncs(workdir, &worktree_syncs)?;
 
     let self_exe = git::loom_exe_path()?;
 

--- a/src/git/git_rebase.rs
+++ b/src/git/git_rebase.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::{Result, bail};
 
 /// Outcome of a rebase operation.
+#[derive(Debug)]
 pub enum RebaseOutcome {
     Completed,
     Conflicted,
@@ -41,6 +42,9 @@ pub fn continue_rebase(workdir: &Path) -> Result<RebaseOutcome> {
     );
 
     if output.status.success() {
+        // If this completed the rebase (rather than pausing at another step),
+        // sync worktrees whose checked-out branch was rewritten.
+        super::git_worktree::finish_worktree_syncs(workdir);
         Ok(RebaseOutcome::Completed)
     } else {
         Ok(RebaseOutcome::Conflicted)
@@ -96,7 +100,10 @@ pub fn rebase_onto(workdir: &Path, newbase: &str, upstream: &str) -> Result<()> 
 
 /// Abort an in-progress rebase.
 pub fn rebase_abort(workdir: &Path) -> Result<()> {
-    super::run_git(workdir, &["rebase", "--abort"])
+    super::run_git(workdir, &["rebase", "--abort"])?;
+    // The abort restored all branch refs, so this only removes the sync plan.
+    super::git_worktree::finish_worktree_syncs(workdir);
+    Ok(())
 }
 
 /// Check whether a rebase is currently in progress in the repository.

--- a/src/git/git_worktree.rs
+++ b/src/git/git_worktree.rs
@@ -8,8 +8,8 @@
 //!
 //! This module restores the invariant: before a rebase, branches about to be
 //! rewritten are mapped to worktrees. A branch checked out in a dirty external
-//! worktree refuses the whole operation up front; clean worktrees are synced
-//! (`reset --hard`) to the new tip once the rebase completes. Because a rebase
+//! worktree refuses the whole operation up front; clean worktrees are
+//! fast-forwarded to the new tip once the rebase completes. Because a rebase
 //! can pause (conflict or `edit`), the planned syncs are saved to
 //! `<git_dir>/loom/worktree-sync.json` and applied when the rebase machinery
 //! finishes — a sync only fires if the branch ref actually moved away from the
@@ -58,8 +58,6 @@ fn parse_worktree_list(porcelain: &str) -> Vec<WorktreeCheckout> {
             {
                 result.push(WorktreeCheckout { path: p, branch: b });
             }
-            path = None;
-            branch = None;
             skip = false;
         } else if let Some(p) = line.strip_prefix("worktree ") {
             path = Some(PathBuf::from(p));
@@ -76,7 +74,7 @@ fn parse_worktree_list(porcelain: &str) -> Vec<WorktreeCheckout> {
 ///
 /// Dirty means: staged or modified tracked files, unmerged entries, or an
 /// operation in progress (rebase/merge/cherry-pick/revert). Untracked files
-/// alone are clean — `reset --hard` leaves them untouched.
+/// alone are clean — the sync refuses to overwrite them instead.
 pub fn worktree_is_dirty(worktree: &Path) -> Result<bool> {
     let status = super::run_git_stdout(worktree, &["status", "--porcelain"])?;
     if status.lines().any(|line| !line.starts_with("??")) {
@@ -117,6 +115,11 @@ pub fn plan_worktree_syncs(workdir: &Path, branches: &[String]) -> Result<Vec<Pe
     let mut dirty = Vec::new();
     for checkout in worktree_checkouts(workdir)? {
         if !branches.contains(&checkout.branch) {
+            continue;
+        }
+        // A locked worktree whose directory is gone is not marked prunable;
+        // treat it like a prunable one (not checked out).
+        if !checkout.path.exists() {
             continue;
         }
         let canonical = checkout
@@ -161,8 +164,17 @@ pub fn plan_worktree_syncs(workdir: &Path, branches: &[String]) -> Result<Vec<Pe
 }
 
 /// Save the sync plan so it survives a paused rebase (conflict or `edit`).
+///
+/// An empty plan removes any stale file left by an interrupted earlier
+/// operation, so the file always reflects the current one.
 pub fn save_worktree_syncs(workdir: &Path, syncs: &[PendingSync]) -> Result<()> {
     let path = sync_file_path(workdir)?;
+    if syncs.is_empty() {
+        if path.exists() {
+            std::fs::remove_file(&path)?;
+        }
+        return Ok(());
+    }
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).with_context(|| {
             format!(
@@ -187,7 +199,7 @@ pub fn finish_worktree_syncs(workdir: &Path) {
     let Ok(git_dir) = absolute_git_dir(workdir) else {
         return;
     };
-    let file = git_dir.join("loom").join("worktree-sync.json");
+    let file = sync_file_in(&git_dir);
     if !file.exists() || super::rebase_is_in_progress(&git_dir) {
         return;
     }
@@ -210,7 +222,7 @@ pub fn finish_worktree_syncs(workdir: &Path) {
     apply_worktree_syncs(workdir, &syncs);
 }
 
-/// Hard-reset each worktree to its branch's new tip.
+/// Fast-forward each worktree to its branch's new tip.
 fn apply_worktree_syncs(workdir: &Path, syncs: &[PendingSync]) {
     for sync in syncs {
         let Ok(new_tip) = super::rev_parse(workdir, &format!("refs/heads/{}", sync.branch)) else {
@@ -223,24 +235,32 @@ fn apply_worktree_syncs(workdir: &Path, syncs: &[PendingSync]) {
         if !worktree_matches_commit(&sync.path, &sync.old_tip) {
             msg::warn(&format!(
                 "Worktree `{}` was modified while branch `{}` was being rewritten — not synced\n\
-                 Its checkout still matches the old tip {}; reconcile it manually before committing there",
+                 Its index and files are still based on the old tip {} plus your changes, \
+                 while HEAD now points at the rewritten branch; reconcile manually before committing there",
                 sync.path.display(),
                 sync.branch,
                 super::short_hash(&sync.old_tip),
             ));
             continue;
         }
-        match super::reset_hard(&sync.path, &new_tip) {
+        // Fast-forward the checkout old→new. Unlike `reset --hard`, this
+        // refuses — touching nothing — if an untracked file would be
+        // overwritten by a file the rewritten branch newly tracks.
+        match super::run_git(
+            &sync.path,
+            &["read-tree", "-m", "-u", &sync.old_tip, &new_tip],
+        ) {
             Ok(()) => msg::success(&format!(
                 "Synced worktree `{}` to rewritten branch `{}`",
                 sync.path.display(),
                 sync.branch
             )),
-            Err(e) => msg::warn(&format!(
-                "Could not sync worktree `{}` to rewritten branch `{}`: {}",
+            Err(_) => msg::warn(&format!(
+                "Worktree `{}` was not synced to rewritten branch `{}` — untracked files there would be overwritten\n\
+                 Move them away, then run `git -C {} reset --hard`",
                 sync.path.display(),
                 sync.branch,
-                e
+                sync.path.display()
             )),
         }
     }
@@ -254,9 +274,11 @@ fn worktree_matches_commit(worktree: &Path, commit: &str) -> bool {
 }
 
 fn sync_file_path(workdir: &Path) -> Result<PathBuf> {
-    Ok(absolute_git_dir(workdir)?
-        .join("loom")
-        .join("worktree-sync.json"))
+    Ok(sync_file_in(&absolute_git_dir(workdir)?))
+}
+
+fn sync_file_in(git_dir: &Path) -> PathBuf {
+    git_dir.join("loom").join("worktree-sync.json")
 }
 
 /// Resolve the git dir, avoiding a process spawn in the common layout.

--- a/src/git/git_worktree.rs
+++ b/src/git/git_worktree.rs
@@ -1,0 +1,274 @@
+//! Worktree ref safety.
+//!
+//! Loom rebases move branch refs through explicit `update-ref` todo lines,
+//! which bypass git's porcelain check against moving a branch that is checked
+//! out in another worktree. Moving such a ref desyncs that worktree: its index
+//! and files stay at the old tip, so `git status` there shows the old→new
+//! delta as phantom staged changes.
+//!
+//! This module restores the invariant: before a rebase, branches about to be
+//! rewritten are mapped to worktrees. A branch checked out in a dirty external
+//! worktree refuses the whole operation up front; clean worktrees are synced
+//! (`reset --hard`) to the new tip once the rebase completes. Because a rebase
+//! can pause (conflict or `edit`), the planned syncs are saved to
+//! `<git_dir>/loom/worktree-sync.json` and applied when the rebase machinery
+//! finishes — a sync only fires if the branch ref actually moved away from the
+//! recorded old tip AND the worktree still matches that old tip, so applying
+//! after an abort or a worktree modified mid-pause is safe.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::core::msg;
+
+/// A local branch checked out in a worktree.
+///
+/// Detached, bare, and prunable (directory gone) worktrees are excluded.
+#[derive(Debug, PartialEq, Eq)]
+pub struct WorktreeCheckout {
+    pub path: PathBuf,
+    /// Branch name without the `refs/heads/` prefix.
+    pub branch: String,
+}
+
+/// List all worktrees that have a local branch checked out.
+pub fn worktree_checkouts(workdir: &Path) -> Result<Vec<WorktreeCheckout>> {
+    let stdout = super::run_git_stdout(workdir, &["worktree", "list", "--porcelain"])?;
+    Ok(parse_worktree_list(&stdout))
+}
+
+/// Parse `git worktree list --porcelain` output.
+///
+/// Each worktree is a block of `attribute [value]` lines separated by a blank
+/// line: `worktree <path>`, `HEAD <sha>`, then `branch refs/heads/<name>` or
+/// `detached`, optionally `bare`, `locked [reason]`, `prunable [reason]`.
+fn parse_worktree_list(porcelain: &str) -> Vec<WorktreeCheckout> {
+    let mut result = Vec::new();
+    let mut path: Option<PathBuf> = None;
+    let mut branch: Option<String> = None;
+    let mut skip = false;
+
+    // Trailing sentinel so the last block is flushed even without a blank line.
+    for line in porcelain.lines().chain(std::iter::once("")) {
+        if line.is_empty() {
+            if let (Some(p), Some(b)) = (path.take(), branch.take())
+                && !skip
+            {
+                result.push(WorktreeCheckout { path: p, branch: b });
+            }
+            path = None;
+            branch = None;
+            skip = false;
+        } else if let Some(p) = line.strip_prefix("worktree ") {
+            path = Some(PathBuf::from(p));
+        } else if let Some(b) = line.strip_prefix("branch refs/heads/") {
+            branch = Some(b.to_string());
+        } else if line == "bare" || line.starts_with("prunable") {
+            skip = true;
+        }
+    }
+    result
+}
+
+/// Whether a worktree has local changes that a ref rewrite would desync.
+///
+/// Dirty means: staged or modified tracked files, unmerged entries, or an
+/// operation in progress (rebase/merge/cherry-pick/revert). Untracked files
+/// alone are clean — `reset --hard` leaves them untouched.
+pub fn worktree_is_dirty(worktree: &Path) -> Result<bool> {
+    let status = super::run_git_stdout(worktree, &["status", "--porcelain"])?;
+    if status.lines().any(|line| !line.starts_with("??")) {
+        return Ok(true);
+    }
+    let git_dir = absolute_git_dir(worktree)?;
+    Ok(super::rebase_is_in_progress(&git_dir)
+        || git_dir.join("MERGE_HEAD").exists()
+        || git_dir.join("CHERRY_PICK_HEAD").exists()
+        || git_dir.join("REVERT_HEAD").exists())
+}
+
+/// A worktree to hard-reset once its checked-out branch has been rewritten.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PendingSync {
+    pub branch: String,
+    pub path: PathBuf,
+    /// The branch tip before the rewrite. A sync only fires if the branch
+    /// moved away from this AND the worktree still matches it.
+    pub old_tip: String,
+}
+
+/// Map branches about to be rewritten to external worktrees.
+///
+/// Bails if any of them is checked out in a dirty external worktree (refusing
+/// the operation before anything is rewritten). Returns the sync plan for the
+/// clean ones. The worktree loom itself runs in is exempt — the rebase moves
+/// its ref, index, and files together.
+pub fn plan_worktree_syncs(workdir: &Path, branches: &[String]) -> Result<Vec<PendingSync>> {
+    if branches.is_empty() {
+        return Ok(Vec::new());
+    }
+    let current = workdir
+        .canonicalize()
+        .unwrap_or_else(|_| workdir.to_path_buf());
+
+    let mut syncs = Vec::new();
+    let mut dirty = Vec::new();
+    for checkout in worktree_checkouts(workdir)? {
+        if !branches.contains(&checkout.branch) {
+            continue;
+        }
+        let canonical = checkout
+            .path
+            .canonicalize()
+            .unwrap_or_else(|_| checkout.path.clone());
+        if canonical == current {
+            continue;
+        }
+        if worktree_is_dirty(&checkout.path)? {
+            dirty.push(checkout);
+        } else {
+            let old_tip = super::rev_parse(workdir, &format!("refs/heads/{}", checkout.branch))?;
+            syncs.push(PendingSync {
+                branch: checkout.branch,
+                path: checkout.path,
+                old_tip,
+            });
+        }
+    }
+
+    match dirty.as_slice() {
+        [] => Ok(syncs),
+        [one] => bail!(
+            "Cannot rewrite branch `{}` — it is checked out at `{}` and that worktree has local changes\n\
+             Commit or stash the changes there, then retry",
+            one.branch,
+            one.path.display()
+        ),
+        many => {
+            let list: Vec<String> = many
+                .iter()
+                .map(|c| format!("  `{}` at `{}`", c.branch, c.path.display()))
+                .collect();
+            bail!(
+                "Cannot rewrite branches that are checked out in worktrees with local changes:\n{}\n\
+                 Commit or stash the changes there, then retry",
+                list.join("\n")
+            )
+        }
+    }
+}
+
+/// Save the sync plan so it survives a paused rebase (conflict or `edit`).
+pub fn save_worktree_syncs(workdir: &Path, syncs: &[PendingSync]) -> Result<()> {
+    let path = sync_file_path(workdir)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create loom state directory '{}'",
+                parent.display()
+            )
+        })?;
+    }
+    let json = serde_json::to_string_pretty(syncs)?;
+    std::fs::write(&path, json)
+        .with_context(|| format!("Failed to write worktree sync file '{}'", path.display()))?;
+    Ok(())
+}
+
+/// Apply (and remove) the saved sync plan once no rebase is in progress.
+///
+/// Safe to call from any completion or abort path: each entry syncs only if
+/// its branch actually moved away from the recorded old tip, so after an
+/// abort (refs restored) this is a no-op that just removes the file. Never
+/// fails — individual problems are reported as warnings.
+pub fn finish_worktree_syncs(workdir: &Path) {
+    let Ok(git_dir) = absolute_git_dir(workdir) else {
+        return;
+    };
+    let file = git_dir.join("loom").join("worktree-sync.json");
+    if !file.exists() || super::rebase_is_in_progress(&git_dir) {
+        return;
+    }
+    let syncs: Vec<PendingSync> = match std::fs::read_to_string(&file)
+        .map_err(anyhow::Error::from)
+        .and_then(|json| serde_json::from_str(&json).map_err(anyhow::Error::from))
+    {
+        Ok(syncs) => syncs,
+        Err(e) => {
+            msg::warn(&format!(
+                "Could not read worktree sync file '{}': {}",
+                file.display(),
+                e
+            ));
+            let _ = std::fs::remove_file(&file);
+            return;
+        }
+    };
+    let _ = std::fs::remove_file(&file);
+    apply_worktree_syncs(workdir, &syncs);
+}
+
+/// Hard-reset each worktree to its branch's new tip.
+fn apply_worktree_syncs(workdir: &Path, syncs: &[PendingSync]) {
+    for sync in syncs {
+        let Ok(new_tip) = super::rev_parse(workdir, &format!("refs/heads/{}", sync.branch)) else {
+            // Branch deleted by the operation (e.g. drop) — nothing to sync.
+            continue;
+        };
+        if new_tip == sync.old_tip || !sync.path.exists() {
+            continue;
+        }
+        if !worktree_matches_commit(&sync.path, &sync.old_tip) {
+            msg::warn(&format!(
+                "Worktree `{}` was modified while branch `{}` was being rewritten — not synced\n\
+                 Its checkout still matches the old tip {}; reconcile it manually before committing there",
+                sync.path.display(),
+                sync.branch,
+                super::short_hash(&sync.old_tip),
+            ));
+            continue;
+        }
+        match super::reset_hard(&sync.path, &new_tip) {
+            Ok(()) => msg::success(&format!(
+                "Synced worktree `{}` to rewritten branch `{}`",
+                sync.path.display(),
+                sync.branch
+            )),
+            Err(e) => msg::warn(&format!(
+                "Could not sync worktree `{}` to rewritten branch `{}`: {}",
+                sync.path.display(),
+                sync.branch,
+                e
+            )),
+        }
+    }
+}
+
+/// Whether the worktree's index and files both match the given commit's tree.
+/// Untracked files are ignored.
+fn worktree_matches_commit(worktree: &Path, commit: &str) -> bool {
+    super::run_git(worktree, &["diff", "--quiet", "--cached", commit]).is_ok()
+        && super::run_git(worktree, &["diff", "--quiet", commit]).is_ok()
+}
+
+fn sync_file_path(workdir: &Path) -> Result<PathBuf> {
+    Ok(absolute_git_dir(workdir)?
+        .join("loom")
+        .join("worktree-sync.json"))
+}
+
+/// Resolve the git dir, avoiding a process spawn in the common layout.
+fn absolute_git_dir(workdir: &Path) -> Result<PathBuf> {
+    let dot_git = workdir.join(".git");
+    if dot_git.is_dir() {
+        return Ok(dot_git);
+    }
+    let out = super::run_git_stdout(workdir, &["rev-parse", "--absolute-git-dir"])?;
+    Ok(PathBuf::from(out.trim()))
+}
+
+#[cfg(test)]
+#[path = "git_worktree_test.rs"]
+mod tests;

--- a/src/git/git_worktree_test.rs
+++ b/src/git/git_worktree_test.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use super::{WorktreeCheckout, parse_worktree_list};
+use super::{PendingSync, WorktreeCheckout, parse_worktree_list};
 use crate::core::test_helpers::TestRepo;
 use crate::core::weave;
 use crate::core::weave::Weave;
@@ -145,6 +145,77 @@ fn untracked_file_does_not_block_and_survives_sync() {
         std::fs::read_to_string(wt.join("notes.txt")).unwrap(),
         "scratch"
     );
+}
+
+#[test]
+fn untracked_collision_blocks_sync_but_preserves_file() {
+    let (t, wt, newbase) = setup_worktree_repo("u1.txt");
+    let old_feature = t.get_branch_target("feature");
+    // The rewritten feature will newly track u1.txt (from newbase); an
+    // untracked u1.txt in the worktree must never be overwritten by the sync.
+    std::fs::write(wt.join("u1.txt"), "draft").unwrap();
+
+    let outcome = weave_rebase(&t, &newbase).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Completed));
+
+    // The branch was rewritten, but the sync refused and the draft survives.
+    assert_ne!(t.get_branch_target("feature"), old_feature);
+    assert_eq!(std::fs::read_to_string(wt.join("u1.txt")).unwrap(), "draft");
+    assert!(
+        !wt_status(&wt).trim().is_empty(),
+        "worktree stays desynced when the sync is refused"
+    );
+    assert!(!pending_sync_file(&t).exists());
+}
+
+#[test]
+fn edit_pause_saves_plan_and_syncs_on_continue() {
+    let (t, wt, newbase) = setup_worktree_repo("u1.txt");
+    let old_feature = t.get_branch_target("feature");
+
+    // An `edit` at the feature tip: git rebase exits successfully but stays
+    // in progress, so the sync must wait for the continue.
+    let mut graph = Weave::from_repo(&t.repo).unwrap();
+    graph.edit_commit(old_feature);
+    let todo = graph.to_todo();
+    let outcome = weave::run_rebase(&t.workdir(), Some(&newbase), &todo).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Completed));
+    assert!(git::rebase_is_in_progress(t.repo.path()));
+    assert!(
+        pending_sync_file(&t).exists(),
+        "sync plan should survive the edit pause"
+    );
+
+    let outcome = git::continue_rebase(&t.workdir()).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Completed));
+
+    let new_feature = t.get_branch_target("feature");
+    assert_ne!(new_feature, old_feature);
+    assert_eq!(
+        git::rev_parse(&wt, "HEAD").unwrap(),
+        new_feature.to_string()
+    );
+    assert!(wt_status(&wt).trim().is_empty());
+    assert!(!pending_sync_file(&t).exists());
+}
+
+#[test]
+fn finish_skips_deleted_branch_and_removes_file() {
+    let t = TestRepo::new_with_remote();
+    let workdir = t.workdir();
+    git::save_worktree_syncs(
+        &workdir,
+        &[PendingSync {
+            branch: "nonexistent".to_string(),
+            path: workdir.clone(),
+            old_tip: t.head_oid().to_string(),
+        }],
+    )
+    .unwrap();
+    assert!(pending_sync_file(&t).exists());
+
+    git::finish_worktree_syncs(&workdir);
+    assert!(!pending_sync_file(&t).exists());
 }
 
 #[test]

--- a/src/git/git_worktree_test.rs
+++ b/src/git/git_worktree_test.rs
@@ -1,0 +1,310 @@
+use std::path::{Path, PathBuf};
+
+use super::{WorktreeCheckout, parse_worktree_list};
+use crate::core::test_helpers::TestRepo;
+use crate::core::weave;
+use crate::core::weave::Weave;
+use crate::git::{self, RebaseOutcome};
+
+#[test]
+fn parse_worktree_list_filters_special_worktrees() {
+    let porcelain = "\
+worktree /repo
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree /repo-wt
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/feature
+
+worktree /repo-detached
+HEAD 3333333333333333333333333333333333333333
+detached
+
+worktree /repo-bare
+bare
+
+worktree /repo-gone
+HEAD 4444444444444444444444444444444444444444
+branch refs/heads/gone
+prunable gitdir file points to non-existent location
+";
+    let list = parse_worktree_list(porcelain);
+    assert_eq!(
+        list,
+        vec![
+            WorktreeCheckout {
+                path: PathBuf::from("/repo"),
+                branch: "main".to_string(),
+            },
+            WorktreeCheckout {
+                path: PathBuf::from("/repo-wt"),
+                branch: "feature".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn current_worktree_is_exempt() {
+    let t = TestRepo::new_with_remote();
+    t.commit("C1", "c1.txt");
+    // Dirty the current worktree — its branch moves together with it, so
+    // planning a rewrite of that branch must neither bail nor plan a sync.
+    t.write_file("c1.txt", "dirty");
+    let syncs = git::plan_worktree_syncs(&t.workdir(), &["integration".to_string()]).unwrap();
+    assert!(syncs.is_empty());
+}
+
+/// Weave setup: `feature` (a1.txt) woven into `integration`, checked out in
+/// an external worktree, plus a `newbase` branch to rebase onto so the
+/// rewrite produces different OIDs.
+///
+/// `newbase_file` is the file committed on `newbase`: use a fresh name for a
+/// clean rebase, or "a1.txt" to force a conflict with the feature commit.
+fn setup_worktree_repo(newbase_file: &str) -> (TestRepo, PathBuf, String) {
+    let t = TestRepo::new_with_remote();
+    let base = t.find_remote_branch_target("origin/main").to_string();
+    t.create_branch_at("feature", &base);
+    t.switch_branch("feature");
+    t.commit("A1", "a1.txt");
+    t.switch_branch("integration");
+    t.commit("Int", "int.txt");
+    t.merge_no_ff("feature");
+
+    t.create_branch_at("newbase", &base);
+    t.switch_branch("newbase");
+    t.commit("N1", newbase_file);
+    let newbase = t.head_oid().to_string();
+    t.switch_branch("integration");
+
+    let wt = t.workdir().parent().unwrap().join("wt");
+    git::run_git(
+        &t.workdir(),
+        &["worktree", "add", wt.to_str().unwrap(), "feature"],
+    )
+    .unwrap();
+    (t, wt, newbase)
+}
+
+fn weave_rebase(t: &TestRepo, newbase: &str) -> anyhow::Result<RebaseOutcome> {
+    let graph = Weave::from_repo(&t.repo).unwrap();
+    let todo = graph.to_todo();
+    weave::run_rebase(&t.workdir(), Some(newbase), &todo)
+}
+
+fn wt_status(wt: &Path) -> String {
+    git::run_git_stdout(wt, &["status", "--porcelain"]).unwrap()
+}
+
+fn pending_sync_file(t: &TestRepo) -> PathBuf {
+    t.repo.path().join("loom").join("worktree-sync.json")
+}
+
+#[test]
+fn clean_worktree_is_synced_after_rewrite() {
+    let (t, wt, newbase) = setup_worktree_repo("u1.txt");
+    let old_feature = t.get_branch_target("feature");
+
+    let outcome = weave_rebase(&t, &newbase).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Completed));
+
+    let new_feature = t.get_branch_target("feature");
+    assert_ne!(new_feature, old_feature, "branch should be rewritten");
+
+    // The worktree's HEAD, index, and files all follow the new tip.
+    assert_eq!(
+        git::rev_parse(&wt, "HEAD").unwrap(),
+        new_feature.to_string()
+    );
+    let status = wt_status(&wt);
+    assert!(
+        status.trim().is_empty(),
+        "worktree should be clean: {status}"
+    );
+    assert!(
+        wt.join("u1.txt").exists(),
+        "new base file should be checked out"
+    );
+    assert!(!pending_sync_file(&t).exists());
+}
+
+#[test]
+fn untracked_file_does_not_block_and_survives_sync() {
+    let (t, wt, newbase) = setup_worktree_repo("u1.txt");
+    std::fs::write(wt.join("notes.txt"), "scratch").unwrap();
+
+    let outcome = weave_rebase(&t, &newbase).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Completed));
+
+    assert_eq!(
+        git::rev_parse(&wt, "HEAD").unwrap(),
+        t.get_branch_target("feature").to_string()
+    );
+    assert_eq!(
+        std::fs::read_to_string(wt.join("notes.txt")).unwrap(),
+        "scratch"
+    );
+}
+
+#[test]
+fn dirty_worktree_refuses_rewrite_up_front() {
+    let (t, wt, newbase) = setup_worktree_repo("u1.txt");
+    std::fs::write(wt.join("a1.txt"), "local edit").unwrap();
+    let old_feature = t.get_branch_target("feature");
+    let old_head = t.head_oid();
+
+    let err = weave_rebase(&t, &newbase).unwrap_err().to_string();
+    assert!(
+        err.contains("feature"),
+        "error should name the branch: {err}"
+    );
+    // Git prints Windows paths with forward slashes; compare normalized.
+    let err_slash = err.replace('\\', "/");
+    let wt_slash = wt.to_str().unwrap().replace('\\', "/");
+    assert!(
+        err_slash.contains(&wt_slash),
+        "error should name the worktree path: {err}"
+    );
+    assert!(err.contains("local changes"), "unexpected error: {err}");
+
+    // Nothing was rewritten.
+    assert_eq!(t.get_branch_target("feature"), old_feature);
+    assert_eq!(t.head_oid(), old_head);
+    assert_eq!(
+        std::fs::read_to_string(wt.join("a1.txt")).unwrap(),
+        "local edit"
+    );
+    assert!(!pending_sync_file(&t).exists());
+}
+
+#[test]
+fn staged_change_in_worktree_also_refuses() {
+    let (t, wt, newbase) = setup_worktree_repo("u1.txt");
+    std::fs::write(wt.join("staged.txt"), "staged").unwrap();
+    git::run_git(&wt, &["add", "staged.txt"]).unwrap();
+    let old_feature = t.get_branch_target("feature");
+
+    let err = weave_rebase(&t, &newbase).unwrap_err().to_string();
+    assert!(err.contains("local changes"), "unexpected error: {err}");
+    assert_eq!(t.get_branch_target("feature"), old_feature);
+}
+
+#[test]
+fn detached_worktree_is_unaffected() {
+    let (t, wt, newbase) = setup_worktree_repo("u1.txt");
+    // Turn the worktree into a detached checkout of the same commit.
+    git::run_git(&t.workdir(), &["worktree", "remove", wt.to_str().unwrap()]).unwrap();
+    git::run_git(
+        &t.workdir(),
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            wt.to_str().unwrap(),
+            "feature",
+        ],
+    )
+    .unwrap();
+    let old_feature = t.get_branch_target("feature");
+
+    let outcome = weave_rebase(&t, &newbase).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Completed));
+
+    // The branch was rewritten but the detached worktree stays where it was.
+    assert_ne!(t.get_branch_target("feature"), old_feature);
+    assert_eq!(
+        git::rev_parse(&wt, "HEAD").unwrap(),
+        old_feature.to_string()
+    );
+    assert!(wt_status(&wt).trim().is_empty());
+}
+
+#[test]
+fn conflicted_rebase_syncs_worktree_after_continue() {
+    let (t, wt, newbase) = setup_worktree_repo("a1.txt");
+    let old_feature = t.get_branch_target("feature");
+
+    let outcome = weave_rebase(&t, &newbase).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Conflicted));
+    assert!(
+        pending_sync_file(&t).exists(),
+        "sync plan should be saved while the rebase is paused"
+    );
+    // The worktree is untouched while the rebase is paused.
+    assert_eq!(
+        git::rev_parse(&wt, "HEAD").unwrap(),
+        old_feature.to_string()
+    );
+
+    // Resolve the conflict and continue.
+    t.write_file("a1.txt", "resolved");
+    git::run_git(&t.workdir(), &["add", "a1.txt"]).unwrap();
+    let outcome = git::continue_rebase(&t.workdir()).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Completed));
+
+    let new_feature = t.get_branch_target("feature");
+    assert_ne!(new_feature, old_feature);
+    assert_eq!(
+        git::rev_parse(&wt, "HEAD").unwrap(),
+        new_feature.to_string()
+    );
+    assert!(wt_status(&wt).trim().is_empty());
+    assert_eq!(
+        std::fs::read_to_string(wt.join("a1.txt")).unwrap(),
+        "resolved"
+    );
+    assert!(!pending_sync_file(&t).exists());
+}
+
+#[test]
+fn aborted_rebase_leaves_worktree_alone_and_cleans_up() {
+    let (t, wt, newbase) = setup_worktree_repo("a1.txt");
+    let old_feature = t.get_branch_target("feature");
+    let old_head = t.head_oid();
+
+    let outcome = weave_rebase(&t, &newbase).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Conflicted));
+
+    git::rebase_abort(&t.workdir()).unwrap();
+
+    assert_eq!(t.get_branch_target("feature"), old_feature);
+    assert_eq!(t.head_oid(), old_head);
+    assert_eq!(
+        git::rev_parse(&wt, "HEAD").unwrap(),
+        old_feature.to_string()
+    );
+    assert!(wt_status(&wt).trim().is_empty());
+    assert!(!pending_sync_file(&t).exists());
+}
+
+#[test]
+fn worktree_modified_during_pause_is_not_synced() {
+    let (t, wt, newbase) = setup_worktree_repo("a1.txt");
+    let old_feature = t.get_branch_target("feature");
+
+    let outcome = weave_rebase(&t, &newbase).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Conflicted));
+
+    // The user edits the worktree while the rebase is paused.
+    std::fs::write(wt.join("a1.txt"), "user edit during pause").unwrap();
+
+    t.write_file("a1.txt", "resolved");
+    git::run_git(&t.workdir(), &["add", "a1.txt"]).unwrap();
+    let outcome = git::continue_rebase(&t.workdir()).unwrap();
+    assert!(matches!(outcome, RebaseOutcome::Completed));
+
+    // The branch was rewritten (the worktree's HEAD symref follows it), but
+    // the edited files and index were left alone — no reset --hard happened.
+    let new_feature = t.get_branch_target("feature");
+    assert_ne!(new_feature, old_feature);
+    assert_eq!(
+        git::rev_parse(&wt, "HEAD").unwrap(),
+        new_feature.to_string()
+    );
+    assert_eq!(
+        std::fs::read_to_string(wt.join("a1.txt")).unwrap(),
+        "user edit during pause"
+    );
+    assert!(!pending_sync_file(&t).exists());
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -4,6 +4,7 @@ pub mod git_commit;
 pub mod git_diff;
 pub mod git_merge;
 pub mod git_rebase;
+pub mod git_worktree;
 
 pub use git_apply::{
     apply_cached_patch, apply_cached_patch_reverse, apply_patch, apply_patch_reverse,
@@ -29,6 +30,7 @@ pub use git_rebase::{
     RebaseOutcome, continue_rebase, continue_rebase_or_abort, rebase, rebase_abort,
     rebase_is_in_progress,
 };
+pub use git_worktree::{finish_worktree_syncs, plan_worktree_syncs, save_worktree_syncs};
 
 use std::path::Path;
 use std::process::Command;


### PR DESCRIPTION
feat(worktree): sync or protect branches checked out in other worktrees

Loom's explicit update-ref todo lines bypass git's porcelain check
against moving a branch that is checked out in another worktree, leaving
that worktree's index and files at the old tip — git status there shows
the old-to-new delta as phantom staged changes.

Before each weave rebase, map the todo's update-ref branches to
worktrees: refuse up front if such a worktree has local changes, and
hard-reset clean ones to the rewritten tip once the rebase completes.
The sync plan survives paused rebases in .git/loom/worktree-sync.json;
a sync only fires if the branch actually moved and the worktree still
matches its old tip, so changes made mid-pause are never discarded.

---

fix(worktree): never overwrite untracked files when syncing a worktree

The review of the previous commit found that `reset --hard` in the sync
step clobbers an untracked file when the rewritten branch newly tracks a
file of the same name. Sync with `read-tree -m -u <old> <new>` instead:
byte-identical result on a clean worktree, but it refuses — touching
nothing — on an untracked collision (then loom warns and skips).

Also: always save the sync plan (an empty plan removes a stale file left
by an interrupted run), skip worktrees whose directory is gone but not
marked prunable (locked), fix the self-contradictory not-synced warning,
and document the behavior in spec 004.