### PR TITLE
fix(push): don't set a Gerrit topic from the local branch name

### DIFF
--- a/docs/src/commands/push.md
+++ b/docs/src/commands/push.md
@@ -93,10 +93,10 @@ Pushes the branch with `--force-with-lease`, then checks whether a PR already ex
 ### Gerrit
 
 ```bash
-git push -o topic=<branch> <remote> <branch>:refs/for/<target>
+git push <remote> <branch>:refs/for/<target>
 ```
 
-Uses the `refs/for/` refspec and sets the topic to the branch name. After pushing, any review URLs returned by Gerrit are extracted from the remote output and displayed below the success message.
+Uses the `refs/for/` refspec. No topic is set. After pushing, any review URLs returned by Gerrit are extracted from the remote output and displayed below the success message.
 
 ## PR Title and Description
 

--- a/docs/src/guides/pushing.md
+++ b/docs/src/guides/pushing.md
@@ -10,7 +10,7 @@ git-loom detects your remote type automatically and runs the appropriate command
 
 - **GitHub** — pushes the branch, then checks if a PR exists. If a PR already exists, prints its URL (`PR updated: https://...`). Otherwise creates a PR via the [`gh` CLI](https://cli.github.com/) with a title and description auto-generated from the branch's commits.
 - **Azure DevOps** — pushes the branch, then checks if a PR exists. If a PR already exists, prints its URL. Otherwise creates a PR via the [`az` CLI](https://learn.microsoft.com/en-us/cli/azure/) with a title and description auto-generated from the branch's commits.
-- **Gerrit** — pushes to `refs/for/<target>` (where `<target>` is your upstream branch, e.g. `main` or `master`) with the branch name as topic. Review URLs from the Gerrit remote are displayed after the push.
+- **Gerrit** — pushes to `refs/for/<target>` (where `<target>` is your upstream branch, e.g. `main` or `master`). Review URLs from the Gerrit remote are displayed after the push.
 - **Plain Git** — pushes with `--force-with-lease`.
 
 If `gh` or `az` are not installed, the push still succeeds — you just won't get the automatic PR creation.

--- a/specs/011-push.md
+++ b/specs/011-push.md
@@ -13,7 +13,7 @@ varies significantly depending on the hosting platform:
 
 - **Plain Git** needs `--force-with-lease` because the branch is rebased
 - **GitHub** benefits from opening a pull request after pushing
-- **Gerrit** requires a special `refs/for/` refspec and topic option
+- **Gerrit** requires a special `refs/for/` refspec
 
 `git loom push` unifies these under one command with automatic remote detection.
 
@@ -154,11 +154,11 @@ is not installed, prints a helpful message with a link to install it.
 ### Gerrit
 
 ```bash
-git push -o topic=<branch> <remote> <branch>:refs/for/<target>
+git push <remote> <branch>:refs/for/<target>
 ```
 
-Uses the Gerrit `refs/for/` refspec to create or update a change. Sets the
-topic to the branch name for grouping related changes.
+Uses the Gerrit `refs/for/` refspec to create or update a change. No topic is
+set — Gerrit keeps whatever topic the change already has.
 
 After pushing, stderr from the git push command is captured and scanned for
 review URLs. Lines starting with `remote:` that contain `http://` or `https://`

--- a/src/push.rs
+++ b/src/push.rs
@@ -891,15 +891,14 @@ fn push_gerrit_no_pr(workdir: &Path, remote: &str, branch: &str) -> Result<()> {
     }
 }
 
-/// Push to Gerrit with topic and refs/for/ refspec.
+/// Push to Gerrit with the refs/for/ refspec.
 ///
 /// Captures stderr from the push command and extracts Gerrit review URLs
 /// (lines starting with `remote:` that contain `http://` or `https://`).
 fn push_gerrit(workdir: &Path, remote: &str, branch: &str, target_branch: &str) -> Result<()> {
     let refspec = format!("{}:refs/for/{}", branch, target_branch);
-    let topic_opt = format!("topic={}", branch);
 
-    let stderr = run_push_capture(workdir, &["push", "-o", &topic_opt, remote, &refspec])?;
+    let stderr = run_push_capture(workdir, &["push", remote, &refspec])?;
 
     let mut message = format!(
         "Pushed `{}` to `{}` (Gerrit: `refs/for/{}`)",


### PR DESCRIPTION
The local branch is a wip name and shouldn't become the change's Gerrit
topic. Push to refs/for/<target> without -o topic, leaving the topic to
Gerrit (it keeps whatever the change already has).

Fixes #178