### PR TITLE
fix(drop): fail loudly for commits outside upstream..HEAD

### DIFF
--- a/src/branch/unmerge.rs
+++ b/src/branch/unmerge.rs
@@ -41,7 +41,12 @@ pub fn run(branch: Option<String>) -> Result<()> {
 
     // Build weave and remove the branch section
     let mut graph = Weave::from_repo_with_info(&repo, &info)?;
-    graph.drop_branch(&branch_name);
+    if !graph.drop_branch(&branch_name) {
+        bail!(
+            "Cannot unmerge: branch '{}' not found in weave graph",
+            branch_name
+        );
+    }
 
     let todo = graph.to_todo();
     weave::run_rebase_or_abort(workdir, Some(&graph.base_oid.to_string()), &todo)?;

--- a/src/core/weave.rs
+++ b/src/core/weave.rs
@@ -324,7 +324,8 @@ impl Weave {
         }
 
         for oid in to_drop {
-            self.drop_commit(oid);
+            // Always found: the oids come from the sections themselves
+            let _ = self.drop_commit(oid);
         }
         Ok(())
     }
@@ -333,7 +334,10 @@ impl Weave {
     ///
     /// If the commit is in a branch section and is the last commit, the section
     /// and its merge entry are also removed.
-    pub fn drop_commit(&mut self, oid: Oid) {
+    ///
+    /// Returns false if the commit is not in the graph.
+    #[must_use]
+    pub fn drop_commit(&mut self, oid: Oid) -> bool {
         // Check branch sections first
         for i in 0..self.branch_sections.len() {
             if let Some(pos) = self.branch_sections[i]
@@ -359,16 +363,19 @@ impl Weave {
                         |e| !matches!(e, IntegrationEntry::Merge { label: l, .. } if *l == label),
                     );
                 }
-                return;
+                return true;
             }
         }
 
         // Check integration line
-        if let Some(pos) = self
+        let Some(pos) = self
             .integration_line
             .iter()
             .position(|e| matches!(e, IntegrationEntry::Pick(c) if c.oid == oid))
-            && let IntegrationEntry::Pick(removed) = self.integration_line.remove(pos)
+        else {
+            return false;
+        };
+        if let IntegrationEntry::Pick(removed) = self.integration_line.remove(pos)
             && !removed.update_refs.is_empty()
         {
             // Find the nearest adjacent Pick to transfer refs to
@@ -381,15 +388,19 @@ impl Weave {
                 c.update_refs.extend(removed.update_refs);
             }
         }
+        true
     }
 
     /// Remove an entire branch section and its merge entry.
-    pub fn drop_branch(&mut self, branch_name: &str) {
+    ///
+    /// Returns false if no section matches the branch name.
+    #[must_use]
+    pub fn drop_branch(&mut self, branch_name: &str) -> bool {
         // Find the section that has this branch name
         let Some(idx) = self.branch_sections.iter().position(|s| {
             s.branch_names.contains(&branch_name.to_string()) || s.label == branch_name
         }) else {
-            return;
+            return false;
         };
 
         let old_label = self.branch_sections[idx].label.clone();
@@ -440,6 +451,7 @@ impl Weave {
                 |e| !matches!(e, IntegrationEntry::Merge { label: l, .. } if *l == old_label),
             );
         }
+        true
     }
 
     /// Move a commit to the tip of a branch section.
@@ -682,42 +694,48 @@ impl Weave {
     ///
     /// Renames the section's label and merge line, removes the dropped branch
     /// from branch_names, ensures the keep branch is present.
-    pub fn reassign_branch(&mut self, drop_branch: &str, keep_branch: &str) {
-        if let Some(section) = self
+    ///
+    /// Returns false if no section matches the dropped branch name.
+    #[must_use]
+    pub fn reassign_branch(&mut self, drop_branch: &str, keep_branch: &str) -> bool {
+        let Some(section) = self
             .branch_sections
             .iter_mut()
             .find(|s| s.label == drop_branch || s.branch_names.contains(&drop_branch.to_string()))
-        {
-            let old_label = section.label.clone();
+        else {
+            return false;
+        };
 
-            // If the section was labeled with the drop branch, rename the label
-            if section.label == drop_branch {
-                section.label = keep_branch.to_string();
-            }
+        let old_label = section.label.clone();
 
-            // Remove the drop branch from branch_names
-            section.branch_names.retain(|n| n != drop_branch);
+        // If the section was labeled with the drop branch, rename the label
+        if section.label == drop_branch {
+            section.label = keep_branch.to_string();
+        }
 
-            // Ensure the keep branch is in branch_names
-            if !section.branch_names.contains(&keep_branch.to_string()) {
-                section.branch_names.push(keep_branch.to_string());
-            }
+        // Remove the drop branch from branch_names
+        section.branch_names.retain(|n| n != drop_branch);
 
-            // Update the merge entry label and clear original_oid so the
-            // rebase generates a fresh merge message with the new branch name.
-            let new_label = section.label.clone();
-            for entry in &mut self.integration_line {
-                if let IntegrationEntry::Merge {
-                    label,
-                    original_oid,
-                } = entry
-                    && *label == old_label
-                {
-                    *label = new_label.clone();
-                    *original_oid = None;
-                }
+        // Ensure the keep branch is in branch_names
+        if !section.branch_names.contains(&keep_branch.to_string()) {
+            section.branch_names.push(keep_branch.to_string());
+        }
+
+        // Update the merge entry label and clear original_oid so the
+        // rebase generates a fresh merge message with the new branch name.
+        let new_label = section.label.clone();
+        for entry in &mut self.integration_line {
+            if let IntegrationEntry::Merge {
+                label,
+                original_oid,
+            } = entry
+                && *label == old_label
+            {
+                *label = new_label.clone();
+                *original_oid = None;
             }
         }
+        true
     }
 
     /// Swap two commits within the same sequence.

--- a/src/core/weave_test.rs
+++ b/src/core/weave_test.rs
@@ -212,7 +212,7 @@ fn drop_commit_from_branch_section() {
         }],
     };
 
-    graph.drop_commit(oid(OID_A1));
+    assert!(graph.drop_commit(oid(OID_A1)));
 
     assert_eq!(graph.branch_sections.len(), 1);
     assert_eq!(graph.branch_sections[0].commits.len(), 1);
@@ -239,7 +239,7 @@ fn drop_last_commit_removes_section_and_merge() {
         ],
     };
 
-    graph.drop_commit(oid(OID_A1));
+    assert!(graph.drop_commit(oid(OID_A1)));
 
     assert!(graph.branch_sections.is_empty());
     assert_eq!(graph.integration_line.len(), 1); // Only "Int" pick remains
@@ -257,8 +257,31 @@ fn drop_commit_from_integration_line() {
         ],
     };
 
-    graph.drop_commit(oid(OID_C1));
+    assert!(graph.drop_commit(oid(OID_C1)));
 
+    assert_eq!(graph.integration_line.len(), 1);
+}
+
+#[test]
+fn drop_unknown_commit_or_branch_returns_false() {
+    let mut graph = Weave {
+        base_oid: oid(BASE),
+
+        branch_sections: vec![BranchSection {
+            reset_target: "onto".to_string(),
+            commits: vec![make_commit(OID_A1, "A1")],
+            label: "feature-a".to_string(),
+            branch_names: vec!["feature-a".to_string()],
+        }],
+        integration_line: vec![IntegrationEntry::Pick(make_commit(OID_C1, "C1"))],
+    };
+
+    assert!(!graph.drop_commit(oid("dead")));
+    assert!(!graph.drop_branch("no-such-branch"));
+    assert!(!graph.reassign_branch("no-such-branch", "feature-a"));
+
+    // Graph is unchanged
+    assert_eq!(graph.branch_sections.len(), 1);
     assert_eq!(graph.integration_line.len(), 1);
 }
 
@@ -293,7 +316,7 @@ fn drop_branch_removes_section_and_merge() {
         ],
     };
 
-    graph.drop_branch("feature-a");
+    assert!(graph.drop_branch("feature-a"));
 
     assert_eq!(graph.branch_sections.len(), 1);
     assert_eq!(graph.branch_sections[0].label, "feature-b");
@@ -585,7 +608,7 @@ fn reassign_branch_renames_section() {
         }],
     };
 
-    graph.reassign_branch("feature-a", "feature-b");
+    assert!(graph.reassign_branch("feature-a", "feature-b"));
 
     assert_eq!(graph.branch_sections[0].label, "feature-b");
     assert!(
@@ -774,7 +797,7 @@ fn drop_commit_transfers_update_refs_to_adjacent() {
         }],
     };
 
-    graph.drop_commit(oid("222"));
+    assert!(graph.drop_commit(oid("222")));
 
     // update_refs should transfer to adjacent commit (C1, preceding)
     assert_eq!(graph.branch_sections[0].commits.len(), 2);
@@ -805,7 +828,7 @@ fn drop_commit_transfers_update_refs_to_next_when_first() {
         }],
     };
 
-    graph.drop_commit(oid("111"));
+    assert!(graph.drop_commit(oid("111")));
 
     assert_eq!(graph.branch_sections[0].commits.len(), 1);
     assert!(
@@ -828,7 +851,7 @@ fn drop_commit_on_integration_line_transfers_update_refs() {
         ],
     };
 
-    graph.drop_commit(oid("222"));
+    assert!(graph.drop_commit(oid("222")));
 
     // Should transfer to an adjacent Pick on the integration line
     let picks: Vec<&CommitEntry> = graph
@@ -873,7 +896,7 @@ fn drop_branch_preserves_colocated_update_refs_at_boundary() {
         }],
     };
 
-    graph.drop_branch("feat3");
+    assert!(graph.drop_branch("feat3"));
 
     // feat1 should be the new section label (first ref found)
     assert_eq!(graph.branch_sections[0].label, "feat1");

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -140,6 +140,32 @@ fn drop_commit(repo: &Repository, commit_hash: &str, skip_confirm: bool) -> Resu
     let commit_oid = git2::Oid::from_str(commit_hash)?;
     let info = repo::gather_repo_info(repo, false, 1)?;
 
+    // Refuse commits outside the local range (upstream..HEAD). Stale SHAs from
+    // before a rewrite still resolve via the reflog, and upstream commits
+    // resolve too — dropping those must fail, not pretend to succeed.
+    if !info.commits.iter().any(|c| c.oid == commit_oid) {
+        let short_hash = git::short_hash(commit_hash);
+        let upstream = &info.upstream.label;
+        let in_upstream = repo
+            .merge_base(info.upstream.merge_base_oid, commit_oid)
+            .is_ok_and(|base| base == commit_oid);
+        if in_upstream {
+            bail!(
+                "Commit `{}` is already in the upstream ({})\n\
+                 loom only manages the local commits ({}..HEAD)",
+                short_hash,
+                upstream,
+                upstream
+            );
+        }
+        bail!(
+            "Commit `{}` is not in the local commits ({}..HEAD)\n\
+             If history was rewritten, the SHA may be stale — run `loom` to see the current commits",
+            short_hash,
+            upstream
+        );
+    }
+
     // Check if this commit is the only commit on a branch.
     // If so, delegate to drop_branch for clean section removal.
     let merge_base_oid = info.upstream.merge_base_oid;
@@ -168,7 +194,12 @@ fn drop_commit(repo: &Repository, commit_hash: &str, skip_confirm: bool) -> Resu
     )?;
 
     let mut graph = Weave::from_repo_with_info(repo, &info)?;
-    graph.drop_commit(commit_oid);
+    if !graph.drop_commit(commit_oid) {
+        bail!(
+            "Cannot drop commit: {} not found in weave graph",
+            short_hash
+        );
+    }
 
     let ctx = DropContext {
         commit_hash: commit_hash.to_string(),
@@ -279,10 +310,16 @@ fn drop_branch_with_info(
     let mut graph = Weave::from_repo_with_info(repo, info)?;
 
     if is_woven {
-        if let Some(keep) = colocated_branch {
-            graph.reassign_branch(branch_name, &keep.name);
+        let removed = if let Some(keep) = colocated_branch {
+            graph.reassign_branch(branch_name, &keep.name)
         } else {
-            graph.drop_branch(branch_name);
+            graph.drop_branch(branch_name)
+        };
+        if !removed {
+            bail!(
+                "Cannot drop branch: '{}' not found in weave graph",
+                branch_name
+            );
         }
     } else if owned.is_empty() {
         // Co-located non-woven: no commits to drop, just delete the ref
@@ -292,7 +329,12 @@ fn drop_branch_with_info(
     } else {
         // Non-woven branch: drop each uniquely owned commit individually
         for oid in &owned {
-            graph.drop_commit(*oid);
+            if !graph.drop_commit(*oid) {
+                bail!(
+                    "Cannot drop branch: commit {} not found in weave graph",
+                    oid
+                );
+            }
         }
     }
 

--- a/src/drop_test.rs
+++ b/src/drop_test.rs
@@ -105,6 +105,43 @@ fn drop_one_of_two_commits_preserves_branch() {
     );
 }
 
+#[test]
+fn drop_stale_sha_fails_without_touching_history() {
+    let test_repo = TestRepo::new_with_remote();
+    let b_oid = test_repo.commit("B", "b.txt");
+    let stale_oid = test_repo.commit("C", "c.txt");
+
+    // Rewrite history: C's object stays alive in the reflog but is no longer
+    // in the upstream..HEAD range
+    test_repo.reset_hard(b_oid);
+    let new_tip = test_repo.commit("C2", "c2.txt");
+
+    let result = super::drop_commit(&test_repo.repo, &stale_oid.to_string(), true);
+    let err = result.expect_err("dropping a stale SHA must fail");
+    assert!(
+        err.to_string().contains("not in the local commits"),
+        "unexpected error: {}",
+        err
+    );
+    assert_eq!(test_repo.head_oid(), new_tip, "history must be unchanged");
+}
+
+#[test]
+fn drop_upstream_commit_fails_without_touching_history() {
+    let test_repo = TestRepo::new_with_remote();
+    let local_oid = test_repo.commit("Local", "local.txt");
+    let upstream_oid = test_repo.find_remote_branch_target("origin/main");
+
+    let result = super::drop_commit(&test_repo.repo, &upstream_oid.to_string(), true);
+    let err = result.expect_err("dropping an upstream commit must fail");
+    assert!(
+        err.to_string().contains("already in the upstream"),
+        "unexpected error: {}",
+        err
+    );
+    assert_eq!(test_repo.head_oid(), local_oid, "history must be unchanged");
+}
+
 // ── Drop branch tests ───────────────────────────────────────────────────
 
 #[test]

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -1371,7 +1371,13 @@ fn fold_commit_to_unstaged(repo: &Repository, commit_hash: &str) -> Result<()> {
         let saved_refs = repo::snapshot_branch_refs(repo)?;
 
         let mut graph = Weave::from_repo(repo)?;
-        graph.drop_commit(target_oid);
+        if !graph.drop_commit(target_oid) {
+            bail!(
+                "Commit `{}` is not in the local commits (upstream..HEAD)\n\
+                 If history was rewritten, the SHA may be stale — run `loom` to see the current commits",
+                git::short_hash(commit_hash)
+            );
+        }
 
         let git_dir = repo.path().to_path_buf();
         let fold_ctx = serde_json::to_value(FoldVariant::CommitToUnstaged {


### PR DESCRIPTION
Initial bug report by Claude ;)

"Your parallel rebase had moved my two commits into a branch, so my first git-loom drop of the stale SHA was a no-op (it claimed success but changed nothing)."

The fix:

Stale SHAs (still alive in the reflog) and upstream commits resolve to
real commit objects, so `drop` printed a false success while changing
nothing. Check the range up front with a clear error, and make the Weave
mutators (drop_commit, drop_branch, reassign_branch) return whether they
found their target so no caller can silently no-op (drop, unmerge, fold).
